### PR TITLE
Introduce BaseDao for JDBC helpers

### DIFF
--- a/boxy-core/pom.xml
+++ b/boxy-core/pom.xml
@@ -13,15 +13,6 @@
 
     <dependencies>
 
-        <!-- JDBI3 -->
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-sqlobject</artifactId>
-        </dependency>
 
         <!-- DATABASE CONNECTION POOLING -->
         <dependency>

--- a/boxy-core/src/main/java/boxy/core/dao/ConsumerGroupDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/ConsumerGroupDao.java
@@ -1,37 +1,43 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.ConsumerGroup;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
-@RegisterConstructorMapper(ConsumerGroup.class)
-public interface ConsumerGroupDao extends SqlObject {
+public class ConsumerGroupDao extends BaseDao {
+    private static final RowMapper<ConsumerGroup> MAPPER = rs -> new ConsumerGroup(
+            rs.getLong("id"),
+            rs.getString("tenant"),
+            rs.getString("name")
+    );
 
-    default long create(String tenant, String name) {
-        return getHandle().createQuery("CALL sp_consumer_groups_create(:tenant,:name)")
-                .bind("tenant", tenant)
-                .bind("name", name)
-                .mapTo(Long.class)
-                .one();
+    public ConsumerGroupDao(DataSource ds) {
+        super(ds);
     }
 
-    default void delete(long id) {
-        getHandle().createUpdate("CALL sp_consumer_groups_delete(:id)")
-                .bind("id", id)
-                .execute();
+    public long create(String tenant, String name) throws SQLException {
+        return queryOne("CALL sp_consumer_groups_create(?, ?)", rs -> rs.getLong(1), tenant, name)
+                .orElseThrow();
     }
 
-    @SqlQuery("SELECT * FROM consumer_groups WHERE id = :id")
-    Optional<ConsumerGroup> find(@Bind("id") long id);
+    public void delete(long id) throws SQLException {
+        update("CALL sp_consumer_groups_delete(?)", id);
+    }
 
-    @SqlQuery("SELECT * FROM consumer_groups WHERE tenant = :tenant AND name = :name")
-    Optional<ConsumerGroup> find(@Bind("tenant") String tenant, @Bind("name") String name);
+    public Optional<ConsumerGroup> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM consumer_groups WHERE id = ?", MAPPER, id);
+    }
 
-    @SqlQuery("SELECT * FROM consumer_groups ORDER BY id LIMIT :limit OFFSET :offset")
-    List<ConsumerGroup> findAll(@Bind("limit") int limit, @Bind("offset") int offset);
+    public Optional<ConsumerGroup> find(String tenant, String name) throws SQLException {
+        return queryOne("SELECT * FROM consumer_groups WHERE tenant = ? AND name = ?", MAPPER, tenant, name);
+    }
+
+    public List<ConsumerGroup> findAll(int limit, int offset) throws SQLException {
+        return query("SELECT * FROM consumer_groups ORDER BY id LIMIT ? OFFSET ?", MAPPER, limit, offset);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/EventDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/EventDao.java
@@ -1,23 +1,21 @@
 package boxy.core.dao;
 
-import org.jdbi.v3.sqlobject.SqlObject;
+import boxy.core.jdbc.BaseDao;
 
-public interface EventDao extends SqlObject {
+import javax.sql.DataSource;
+import java.sql.SQLException;
 
-    default void publish(String tenant, String topic, String key, String data) {
-        getHandle().createUpdate("CALL sp_events_publish(:tenant,:topic,:key,:data)")
-                .bind("tenant", tenant)
-                .bind("topic", topic)
-                .bind("key", key)
-                .bind("data", data)
-                .execute();
+public class EventDao extends BaseDao {
+
+    public EventDao(DataSource ds) {
+        super(ds);
     }
 
-    default void publishAdvanced(long partitionId, String data) {
-        getHandle().createUpdate("CALL sp_events_publish_advanced(:pid,:event)")
-                .bind("pid", partitionId)
-                .bind("event", data)
-                .execute();
+    public void publish(String tenant, String topic, String key, String data) throws SQLException {
+        update("CALL sp_events_publish(?,?,?,?)", tenant, topic, key, data);
     }
 
+    public void publishAdvanced(long partitionId, String data) throws SQLException {
+        update("CALL sp_events_publish_advanced(?,?)", partitionId, data);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/LeaseDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/LeaseDao.java
@@ -1,50 +1,55 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.Lease;
 import boxy.core.model.SubscriptionOffset;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
-@RegisterConstructorMapper(Lease.class)
-public interface LeaseDao extends SqlObject {
+public class LeaseDao extends BaseDao {
+    private static final RowMapper<Lease> MAPPER = rs -> new Lease(
+            rs.getLong("subscription_offset_id"),
+            rs.getLong("worker_id"),
+            rs.getLong("version"),
+            rs.getTimestamp("acquired_at").toInstant(),
+            rs.getTimestamp("updated_at").toInstant(),
+            rs.getTimestamp("expires_at").toInstant()
+    );
+    private static final RowMapper<SubscriptionOffset> OFFSET_MAPPER = rs -> new SubscriptionOffset(
+            rs.getLong("id"),
+            rs.getLong("subscription_id"),
+            rs.getLong("partition_id"),
+            rs.getLong("committed_offset"),
+            rs.getLong("high_watermark")
+    );
 
-    @SqlQuery("SELECT * FROM leases WHERE subscription_offset_id = :subscriptionOffsetId")
-    Optional<Lease> find(@Bind("subscriptionOffsetId") long subscriptionOffsetId);
-
-    @SqlQuery("SELECT * FROM leases_available_view LIMIT :limit OFFSET :offset")
-    @RegisterConstructorMapper(SubscriptionOffset.class)
-    List<SubscriptionOffset> leasesAvailable(@Bind("limit") int limit,
-                                             @Bind("offset") int offset);
-
-
-    default boolean acquire(long subscriptionOffsetId, long workerId, long expiresAfter) {
-        return getHandle().createQuery("CALL sp_leases_acquire(:so,:worker,:exp)")
-                .bind("so", subscriptionOffsetId)
-                .bind("worker", workerId)
-                .bind("exp", expiresAfter)
-                .mapTo(Integer.class)
-                .one() > 0;
+    public LeaseDao(DataSource ds) {
+        super(ds);
     }
 
-    default boolean renew(long subscriptionOffsetId, long workerId, long expiresAfter) {
-        return getHandle().createQuery("CALL sp_leases_renew(:so,:worker,:exp)")
-                .bind("so", subscriptionOffsetId)
-                .bind("worker", workerId)
-                .bind("exp", expiresAfter)
-                .mapTo(Integer.class)
-                .one() > 0;
+    public Optional<Lease> find(long subscriptionOffsetId) throws SQLException {
+        return queryOne("SELECT * FROM leases WHERE subscription_offset_id = ?", MAPPER, subscriptionOffsetId);
     }
 
-    default void release(long subscriptionOffsetId, long workerId) {
-        getHandle().createUpdate("CALL sp_leases_release(:so,:worker)")
-                .bind("so", subscriptionOffsetId)
-                .bind("worker", workerId)
-                .execute();
+    public List<SubscriptionOffset> leasesAvailable(int limit, int offset) throws SQLException {
+        return query("SELECT * FROM leases_available_view LIMIT ? OFFSET ?", OFFSET_MAPPER, limit, offset);
     }
 
+    public boolean acquire(long subscriptionOffsetId, long workerId, long expiresAfter) throws SQLException {
+        return queryOne("CALL sp_leases_acquire(?,?,?)", rs -> rs.getInt(1), subscriptionOffsetId, workerId, expiresAfter)
+                .orElse(0) > 0;
+    }
+
+    public boolean renew(long subscriptionOffsetId, long workerId, long expiresAfter) throws SQLException {
+        return queryOne("CALL sp_leases_renew(?,?,?)", rs -> rs.getInt(1), subscriptionOffsetId, workerId, expiresAfter)
+                .orElse(0) > 0;
+    }
+
+    public void release(long subscriptionOffsetId, long workerId) throws SQLException {
+        update("CALL sp_leases_release(?,?)", subscriptionOffsetId, workerId);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/PartitionDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/PartitionDao.java
@@ -1,19 +1,30 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.Partition;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.Optional;
 
-@RegisterConstructorMapper(Partition.class)
-public interface PartitionDao {
+public class PartitionDao extends BaseDao {
+    private static final RowMapper<Partition> MAPPER = rs -> new Partition(
+            rs.getLong("id"),
+            rs.getLong("topic_id"),
+            rs.getInt("partition_number"),
+            rs.getLong("high_watermark")
+    );
 
-    @SqlQuery("SELECT * FROM partitions WHERE id = :id")
-    Optional<Partition> find(@Bind("id") long id);
+    public PartitionDao(DataSource ds) {
+        super(ds);
+    }
 
-    @SqlQuery("SELECT * FROM partitions WHERE topic_id = :topicId AND partition_number = :partitionNumber")
-    Optional<Partition> find(@Bind("topicId") long topicId, @Bind("partitionNumber") int partitionNumber);
+    public Optional<Partition> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM partitions WHERE id = ?", MAPPER, id);
+    }
 
+    public Optional<Partition> find(long topicId, int partitionNumber) throws SQLException {
+        return queryOne("SELECT * FROM partitions WHERE topic_id = ? AND partition_number = ?", MAPPER, topicId, partitionNumber);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/SubscriptionDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/SubscriptionDao.java
@@ -1,48 +1,49 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.Subscription;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
-@RegisterConstructorMapper(Subscription.class)
-public interface SubscriptionDao extends SqlObject {
+public class SubscriptionDao extends BaseDao {
+    private static final RowMapper<Subscription> MAPPER = rs -> new Subscription(
+            rs.getLong("id"),
+            rs.getLong("consumer_group_id"),
+            rs.getLong("topic_id")
+    );
 
-    @SqlQuery("SELECT * FROM subscriptions WHERE id = :id")
-    Optional<Subscription> find(@Bind("id") long id);
-
-    @SqlQuery("SELECT * FROM subscriptions WHERE consumer_group_id = :consumerGroupId AND topic_id = :topicId")
-    Optional<Subscription> find(@Bind("consumerGroupId") long consumerGroupId, @Bind("topicId") long topicId);
-
-    @SqlQuery("SELECT * FROM subscriptions ORDER BY id LIMIT :limit OFFSET :offset")
-    List<Subscription> findAll(@Bind("limit") int limit, @Bind("offset") int offset);
-
-    default long subscribe(long consumerGroupId, long topicId) {
-        return getHandle().createQuery("CALL sp_topics_subscribe(:cg,:topic)")
-                .bind("cg", consumerGroupId)
-                .bind("topic", topicId)
-                .mapTo(Long.class)
-                .one();
+    public SubscriptionDao(DataSource ds) {
+        super(ds);
     }
 
-    default void subscribe(long consumerGroupId, List<Long> topicIds) {
-        final var json = "[" + topicIds.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(",")) + "]";
-        getHandle().createUpdate("CALL sp_topics_subscribe_multi(:cg,:topics)")
-                .bind("cg", consumerGroupId)
-                .bind("topics", json)
-                .execute();
+    public Optional<Subscription> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM subscriptions WHERE id = ?", MAPPER, id);
     }
 
-    default void unsubscribe(long consumerGroupId, List<Long> topicIds) {
-        final var json = "[" + topicIds.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(",")) + "]";
-        getHandle().createUpdate("CALL sp_topics_unsubscribe_multi(:cg,:topics)")
-                .bind("cg", consumerGroupId)
-                .bind("topics", json)
-                .execute();
+    public Optional<Subscription> find(long consumerGroupId, long topicId) throws SQLException {
+        return queryOne("SELECT * FROM subscriptions WHERE consumer_group_id = ? AND topic_id = ?", MAPPER, consumerGroupId, topicId);
     }
 
+    public List<Subscription> findAll(int limit, int offset) throws SQLException {
+        return query("SELECT * FROM subscriptions ORDER BY id LIMIT ? OFFSET ?", MAPPER, limit, offset);
+    }
+
+    public long subscribe(long consumerGroupId, long topicId) throws SQLException {
+        return queryOne("CALL sp_topics_subscribe(?,?)", rs -> rs.getLong(1), consumerGroupId, topicId).orElseThrow();
+    }
+
+    public void subscribe(long consumerGroupId, List<Long> topicIds) throws SQLException {
+        String json = "[" + topicIds.stream().map(String::valueOf).collect(Collectors.joining(",")) + "]";
+        update("CALL sp_topics_subscribe_multi(?,?)", consumerGroupId, json);
+    }
+
+    public void unsubscribe(long consumerGroupId, List<Long> topicIds) throws SQLException {
+        String json = "[" + topicIds.stream().map(String::valueOf).collect(Collectors.joining(",")) + "]";
+        update("CALL sp_topics_unsubscribe_multi(?,?)", consumerGroupId, json);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/SubscriptionOffsetDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/SubscriptionOffsetDao.java
@@ -1,31 +1,40 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.SubscriptionOffset;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
-@RegisterConstructorMapper(SubscriptionOffset.class)
-public interface SubscriptionOffsetDao extends SqlObject {
+public class SubscriptionOffsetDao extends BaseDao {
+    private static final RowMapper<SubscriptionOffset> MAPPER = rs -> new SubscriptionOffset(
+            rs.getLong("id"),
+            rs.getLong("subscription_id"),
+            rs.getLong("partition_id"),
+            rs.getLong("committed_offset"),
+            rs.getLong("high_watermark")
+    );
 
-    default void commit(long id, long offset) {
-        getHandle().createUpdate("CALL sp_commit_offset(:id,:offset)")
-                .bind("id", id)
-                .bind("offset", offset)
-                .execute();
+    public SubscriptionOffsetDao(DataSource ds) {
+        super(ds);
     }
 
-    @SqlQuery("SELECT * FROM subscription_offsets_view WHERE id = :id")
-    Optional<SubscriptionOffset> find(@Bind("id") long id);
+    public void commit(long id, long offset) throws SQLException {
+        update("CALL sp_commit_offset(?,?)", id, offset);
+    }
 
-    @SqlQuery("SELECT * FROM subscription_offsets_view WHERE subscription_id = :subscriptionId AND partition_id = :partitionId")
-    Optional<SubscriptionOffset> find(@Bind("subscriptionId") long subscriptionId, @Bind("partitionId") long partitionId);
+    public Optional<SubscriptionOffset> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM subscription_offsets_view WHERE id = ?", MAPPER, id);
+    }
 
-    @SqlQuery("SELECT * FROM subscription_offsets_view WHERE subscription_id = :subscriptionId ORDER BY id")
-    List<SubscriptionOffset> findAll(@Bind("subscriptionId") long subscriptionId);
+    public Optional<SubscriptionOffset> find(long subscriptionId, long partitionId) throws SQLException {
+        return queryOne("SELECT * FROM subscription_offsets_view WHERE subscription_id = ? AND partition_id = ?", MAPPER, subscriptionId, partitionId);
+    }
 
+    public List<SubscriptionOffset> findAll(long subscriptionId) throws SQLException {
+        return query("SELECT * FROM subscription_offsets_view WHERE subscription_id = ? ORDER BY id", MAPPER, subscriptionId);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/TopicDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/TopicDao.java
@@ -1,33 +1,38 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.Topic;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.Optional;
 
-@RegisterConstructorMapper(Topic.class)
-public interface TopicDao extends SqlObject {
+public class TopicDao extends BaseDao {
+    private static final RowMapper<Topic> MAPPER = rs -> new Topic(
+            rs.getLong("id"),
+            rs.getString("tenant"),
+            rs.getString("name"),
+            rs.getInt("partitions")
+    );
 
-    default long create(String tenant, String name, int partitions) {
-        return getHandle().createQuery("CALL sp_topics_create(:tenant,:name,:parts)")
-                .bind("tenant", tenant)
-                .bind("name", name)
-                .bind("parts", partitions)
-                .mapTo(Long.class)
-                .one();
+    public TopicDao(DataSource ds) {
+        super(ds);
     }
 
-    @SqlQuery("SELECT * FROM topics WHERE id = :id")
-    Optional<Topic> find(@Bind("id") long id);
+    public long create(String tenant, String name, int partitions) throws SQLException {
+        return queryOne("CALL sp_topics_create(?,?,?)", rs -> rs.getLong(1), tenant, name, partitions).orElseThrow();
+    }
 
-    @SqlQuery("SELECT * FROM topics WHERE tenant = :tenant AND name = :name")
-    Optional<Topic> find(@Bind("tenant") String tenant, @Bind("name") String name);
+    public Optional<Topic> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM topics WHERE id = ?", MAPPER, id);
+    }
 
-    @SqlUpdate("CALL sp_topics_delete(:topicId)")
-    void delete(@Bind("topicId") long topicId);
-    
+    public Optional<Topic> find(String tenant, String name) throws SQLException {
+        return queryOne("SELECT * FROM topics WHERE tenant = ? AND name = ?", MAPPER, tenant, name);
+    }
+
+    public void delete(long topicId) throws SQLException {
+        update("CALL sp_topics_delete(?)", topicId);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/dao/WorkerDao.java
+++ b/boxy-core/src/main/java/boxy/core/dao/WorkerDao.java
@@ -1,36 +1,40 @@
 package boxy.core.dao;
 
+import boxy.core.jdbc.BaseDao;
+import boxy.core.jdbc.RowMapper;
 import boxy.core.model.Worker;
-import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
+import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.Optional;
 
-@RegisterConstructorMapper(Worker.class)
-public interface WorkerDao extends SqlObject {
+public class WorkerDao extends BaseDao {
+    private static final RowMapper<Worker> MAPPER = rs -> new Worker(
+            rs.getLong("id"),
+            rs.getString("node_id"),
+            rs.getLong("consumer_group_id"),
+            rs.getInt("weight"),
+            rs.getTimestamp("last_heartbeat").toInstant()
+    );
 
-    default long register(String nodeId, long consumerGroupId, int weight) {
-        return getHandle().createQuery("CALL sp_workers_register(:nodeId,:consumerGroupId,:weight)")
-                .bind("nodeId", nodeId)
-                .bind("consumerGroupId", consumerGroupId)
-                .bind("weight", weight)
-                .mapTo(Long.class)
-                .one();
+    public WorkerDao(DataSource ds) {
+        super(ds);
     }
 
-    default void deregister(long id) {
-        getHandle().createUpdate("CALL sp_workers_deregister(:id)")
-                .bind("id", id)
-                .execute();
+    public long register(String nodeId, long consumerGroupId, int weight) throws SQLException {
+        return queryOne("CALL sp_workers_register(?,?,?)", rs -> rs.getLong(1), nodeId, consumerGroupId, weight)
+                .orElseThrow();
     }
 
-    @SqlQuery("SELECT * FROM workers WHERE id = :id")
-    Optional<Worker> find(@Bind("id") long id);
+    public void deregister(long id) throws SQLException {
+        update("CALL sp_workers_deregister(?)", id);
+    }
 
-    @SqlQuery("SELECT * FROM workers WHERE node_id = :nodeId AND consumer_group_id = :consumerGroupId")
-    Optional<Worker> find(@Bind("nodeId") String nodeId,
-                          @Bind("consumerGroupId") long consumerGroupId);
+    public Optional<Worker> find(long id) throws SQLException {
+        return queryOne("SELECT * FROM workers WHERE id = ?", MAPPER, id);
+    }
 
+    public Optional<Worker> find(String nodeId, long consumerGroupId) throws SQLException {
+        return queryOne("SELECT * FROM workers WHERE node_id = ? AND consumer_group_id = ?", MAPPER, nodeId, consumerGroupId);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/jdbc/BaseDao.java
+++ b/boxy-core/src/main/java/boxy/core/jdbc/BaseDao.java
@@ -1,0 +1,49 @@
+package boxy.core.jdbc;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public abstract class BaseDao {
+    protected final DataSource ds;
+
+    protected BaseDao(DataSource ds) {
+        this.ds = ds;
+    }
+
+    protected <T> Optional<T> queryOne(String sql, RowMapper<T> mapper, Object... params) throws SQLException {
+        var list = query(sql, mapper, params);
+        if (list.isEmpty()) return Optional.empty();
+        return Optional.of(list.get(0));
+    }
+
+    protected <T> List<T> query(String sql, RowMapper<T> mapper, Object... params) throws SQLException {
+        try (Connection conn = ds.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            bind(ps, params);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<T> results = new ArrayList<>();
+                while (rs.next()) {
+                    results.add(mapper.map(rs));
+                }
+                return results;
+            }
+        }
+    }
+
+    protected int update(String sql, Object... params) throws SQLException {
+        try (Connection conn = ds.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            bind(ps, params);
+            return ps.executeUpdate();
+        }
+    }
+
+    private static void bind(PreparedStatement ps, Object... params) throws SQLException {
+        for (int i = 0; i < params.length; i++) {
+            ps.setObject(i + 1, params[i]);
+        }
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/jdbc/RowMapper.java
+++ b/boxy-core/src/main/java/boxy/core/jdbc/RowMapper.java
@@ -1,0 +1,9 @@
+package boxy.core.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface RowMapper<T> {
+    T map(ResultSet rs) throws SQLException;
+}

--- a/boxy-core/src/main/java/boxy/core/service/EventService.java
+++ b/boxy-core/src/main/java/boxy/core/service/EventService.java
@@ -1,14 +1,15 @@
 package boxy.core.service;
 
 import boxy.core.dao.EventDao;
-import org.jdbi.v3.core.Jdbi;
+
+import javax.sql.DataSource;
 
 public class EventService {
 
     private final EventDao eventDao;
 
-    public EventService(Jdbi jdbi) {
-        this.eventDao = jdbi.onDemand(EventDao.class);
+    public EventService(DataSource dataSource) {
+        this.eventDao = new EventDao(dataSource);
     }
 
     public void publish(String tenant, String topicName, String key, String data) {

--- a/boxy-core/src/main/java/boxy/core/service/SubscriptionService.java
+++ b/boxy-core/src/main/java/boxy/core/service/SubscriptionService.java
@@ -4,7 +4,8 @@ import boxy.core.dao.ConsumerGroupDao;
 import boxy.core.dao.SubscriptionDao;
 import boxy.core.dao.TopicDao;
 import boxy.core.model.Subscription;
-import org.jdbi.v3.core.Jdbi;
+
+import javax.sql.DataSource;
 
 import java.util.Arrays;
 import java.util.NoSuchElementException;
@@ -16,10 +17,10 @@ public class SubscriptionService {
     private final TopicDao topicDao;
     private final ConsumerGroupDao consumerGroupDao;
 
-    public SubscriptionService(Jdbi jdbi) {
-        this.subscriptionDao = jdbi.onDemand(SubscriptionDao.class);
-        this.topicDao = jdbi.onDemand(TopicDao.class);
-        this.consumerGroupDao = jdbi.onDemand(ConsumerGroupDao.class);
+    public SubscriptionService(DataSource dataSource) {
+        this.subscriptionDao = new SubscriptionDao(dataSource);
+        this.topicDao = new TopicDao(dataSource);
+        this.consumerGroupDao = new ConsumerGroupDao(dataSource);
     }
 
     public Optional<Subscription> find(String tenant, String consumerGroupName, String topic) {

--- a/boxy-core/src/test/java/boxy/core/it/BaseIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/BaseIT.java
@@ -6,9 +6,6 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
-import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.sql.SQLException;
 import java.util.Map;
+import javax.sql.DataSource;
 
 public abstract class BaseIT {
 
@@ -39,7 +37,7 @@ public abstract class BaseIT {
                             "--performance_schema=OFF"             // turn off the perf schema overhead
                     );
 
-    protected Jdbi jdbi;
+    protected DataSource dataSource;
 
 
     @BeforeAll
@@ -61,47 +59,44 @@ public abstract class BaseIT {
     }
 
     @BeforeEach
-    void setupJDBI() {
-        jdbi = Jdbi.create(DataSourceProvider.dataSource());
-        jdbi.installPlugin(new SqlObjectPlugin());
+    void setupDataSource() {
+        dataSource = DataSourceProvider.dataSource();
     }
 
     @AfterEach
     void teardownDB() throws SQLException {
-        jdbi.useHandle(handle -> {
-            final var productName = handle.getConnection()
-                    .getMetaData()
-                    .getDatabaseProductName();
+        try (var conn = dataSource.getConnection()) {
+            final var productName = conn.getMetaData().getDatabaseProductName();
             if ("PostgreSQL".equalsIgnoreCase(productName)) {
-                teardownPGSQL(handle);
+                teardownPGSQL(conn);
             } else if ("MySQL".equalsIgnoreCase(productName)) {
-                teardownMYSQL(handle);
+                teardownMYSQL(conn);
             } else {
-                throw new UnsupportedOperationException(String.format("Database %s is not supported", productName));
+                throw new UnsupportedOperationException("Database " + productName + " is not supported");
             }
-        });
+        }
         DataSourceProvider.close();
     }
-
-    void teardownPGSQL(final Handle handle) {
-        final var query = "SELECT string_agg(quote_ident(tableName), ', ') FROM pg_tables WHERE schemaname = 'public'";
-        handle.execute(String.format(
-                "TRUNCATE TABLE %s RESTART IDENTITY CASCADE;",
-                handle.createQuery(query).mapTo(String.class).one()));
+    void teardownPGSQL(final java.sql.Connection conn) throws SQLException {
+        try (var stmt = conn.createStatement()) {
+            final var rs = stmt.executeQuery("SELECT string_agg(quote_ident(tablename), ', ') FROM pg_tables WHERE schemaname = 'public'");
+            rs.next();
+            final var tables = rs.getString(1);
+            stmt.execute("TRUNCATE TABLE " + tables + " RESTART IDENTITY CASCADE;");
+        }
     }
 
-    void teardownMYSQL(final Handle handle) {
-        handle.execute("SET FOREIGN_KEY_CHECKS = 0;");
-        final var tables = handle.createQuery("""
-                        SELECT table_name FROM information_schema.tables
-                        WHERE table_type = 'BASE TABLE' AND table_schema = DATABASE()
-                        """)
-                .mapTo(String.class)
-                .list();
-        final var batch = handle.createBatch();
-        tables.forEach(table -> batch.add("TRUNCATE TABLE `" + table + "`"));
-        batch.execute();
-        handle.execute("SET FOREIGN_KEY_CHECKS = 1;");
+    void teardownMYSQL(final java.sql.Connection conn) throws SQLException {
+        try (var stmt = conn.createStatement()) {
+            stmt.execute("SET FOREIGN_KEY_CHECKS = 0;");
+            try (var rs = stmt.executeQuery("SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema = DATABASE()")) {
+                while (rs.next()) {
+                    stmt.addBatch("TRUNCATE TABLE `" + rs.getString(1) + "`");
+                }
+                stmt.executeBatch();
+            }
+            stmt.execute("SET FOREIGN_KEY_CHECKS = 1;");
+        }
     }
 
 }

--- a/boxy-core/src/test/java/boxy/core/it/BenchmarkIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/BenchmarkIT.java
@@ -30,9 +30,9 @@ public class BenchmarkIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        eventService = new EventService(jdbi);
-        topicDao = jdbi.onDemand(TopicDao.class);
-        partitionDao = jdbi.onDemand(PartitionDao.class);
+        eventService = new EventService(dataSource);
+        topicDao = new TopicDao(dataSource);
+        partitionDao = new PartitionDao(dataSource);
         recorder = new Recorder(TimeUnit.SECONDS.toNanos(1), 3);
     }
 

--- a/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
@@ -17,8 +17,8 @@ public class ConsumerGroupIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        consumerGroupDao = jdbi.onDemand(ConsumerGroupDao.class);
-        data = TestData.seed(jdbi);
+        consumerGroupDao = new ConsumerGroupDao(dataSource);
+        data = TestData.seed(dataSource);
     }
 
     @Test

--- a/boxy-core/src/test/java/boxy/core/it/LeaseIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/LeaseIT.java
@@ -16,8 +16,8 @@ public class LeaseIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        leaseDao = jdbi.onDemand(LeaseDao.class);
-        data = TestData.seed(jdbi);
+        leaseDao = new LeaseDao(dataSource);
+        data = TestData.seed(dataSource);
     }
 
 

--- a/boxy-core/src/test/java/boxy/core/it/ProcessorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/ProcessorIT.java
@@ -26,10 +26,10 @@ public class ProcessorIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        subscriptionService = new SubscriptionService(jdbi);
-        eventService = new EventService(jdbi);
-        leaseDao = jdbi.onDemand(LeaseDao.class);
-        data = TestData.seed(jdbi);
+        subscriptionService = new SubscriptionService(dataSource);
+        eventService = new EventService(dataSource);
+        leaseDao = new LeaseDao(dataSource);
+        data = TestData.seed(dataSource);
     }
 
     @Test

--- a/boxy-core/src/test/java/boxy/core/it/SubscriptionIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/SubscriptionIT.java
@@ -22,10 +22,10 @@ public class SubscriptionIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        consumerGroupDao = jdbi.onDemand(ConsumerGroupDao.class);
-        subscriptionService = new SubscriptionService(jdbi);
-        topicDao = jdbi.onDemand(TopicDao.class);
-        data = TestData.seed(jdbi);
+        consumerGroupDao = new ConsumerGroupDao(dataSource);
+        subscriptionService = new SubscriptionService(dataSource);
+        topicDao = new TopicDao(dataSource);
+        data = TestData.seed(dataSource);
     }
 
     @Test
@@ -41,7 +41,7 @@ public class SubscriptionIT extends BaseIT {
     @Test
     void created_whenCreatedMultipleTimes_allPresent() {
         // VALIDATE
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0)).hasSize(8);
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0)).hasSize(8);
     }
 
     @Test
@@ -52,24 +52,24 @@ public class SubscriptionIT extends BaseIT {
         subscriptionService.unsubscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_C);
         subscriptionService.unsubscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_D);
         // VALIDATE
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0)).hasSize(4);
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0)).hasSize(4);
     }
 
     @Test
     void delete_whenDeletedMultipleTimes_allNotPresent() {
         // UNSUBSCRIBE AND VALIDATE 1
         subscriptionService.unsubscribe(TENANT_1, CONSUMER_GROUP_A, TOPIC_A, TOPIC_B);
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0)).hasSize(6);
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0)).hasSize(6);
         // UNSUBSCRIBE AND VALIDATE 2
         subscriptionService.unsubscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_C, TOPIC_D);
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0)).hasSize(4);
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0)).hasSize(4);
     }
 
 
     @Test
     void deleteAll_whenDeleted_otherConsumerGroupsUnaffected() {
         // VALIDATE
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0))
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0))
                 .hasSize(8)
                 .extracting(Subscription::consumerGroupId)
                 .containsAll(data.subscriptions().stream().map(Subscription::consumerGroupId).toList());
@@ -79,7 +79,7 @@ public class SubscriptionIT extends BaseIT {
         subscriptionService.unsubscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_C);
         subscriptionService.unsubscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_D);
         // VALIDATE
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(100, 0))
+        assertThat(new SubscriptionDao(dataSource).findAll(100, 0))
                 .hasSize(4);
     }
 
@@ -90,11 +90,11 @@ public class SubscriptionIT extends BaseIT {
         final var s3 = subscriptionService.find(TENANT_1, CONSUMER_GROUP_B, TOPIC_A).orElseThrow().id();
         final var s4 = subscriptionService.find(TENANT_1, CONSUMER_GROUP_B, TOPIC_B).orElseThrow().id();
         // PAGE 1
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(2, 0))
+        assertThat(new SubscriptionDao(dataSource).findAll(2, 0))
                 .extracting(Subscription::id)
                 .containsExactlyInAnyOrder(s1, s2);
         // PAGE 2
-        assertThat(jdbi.onDemand(SubscriptionDao.class).findAll(2, 2))
+        assertThat(new SubscriptionDao(dataSource).findAll(2, 2))
                 .extracting(Subscription::id)
                 .containsExactlyInAnyOrder(s3, s4);
 

--- a/boxy-core/src/test/java/boxy/core/it/SubscriptionOffsetIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/SubscriptionOffsetIT.java
@@ -17,8 +17,8 @@ public class SubscriptionOffsetIT extends BaseIT {
 
     @BeforeEach
     void setup() {
-        subscriptionOffsetDao = jdbi.onDemand(SubscriptionOffsetDao.class);
-        data = TestData.seed(jdbi);
+        subscriptionOffsetDao = new SubscriptionOffsetDao(dataSource);
+        data = TestData.seed(dataSource);
     }
 
     @Test

--- a/boxy-core/src/test/java/boxy/core/it/TestData.java
+++ b/boxy-core/src/test/java/boxy/core/it/TestData.java
@@ -3,7 +3,8 @@ package boxy.core.it;
 import boxy.core.dao.*;
 import boxy.core.model.*;
 import boxy.core.service.SubscriptionService;
-import org.jdbi.v3.core.Jdbi;
+
+import javax.sql.DataSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,13 +31,12 @@ public record TestData(Topic topic,
     public static final String PARTY_1 = UUID.randomUUID().toString();
     public static final String PARTY_2 = UUID.randomUUID().toString();
 
-    public static TestData seed(final Jdbi jdbi) {
-        // Initialize JDBI Objects
-        final var topicDao = jdbi.onDemand(TopicDao.class);
-        final var consumerGroupDao = jdbi.onDemand(ConsumerGroupDao.class);
-        final var subscriptionService = new SubscriptionService(jdbi);
-        final var subscriptionOffsetDao = jdbi.onDemand(SubscriptionOffsetDao.class);
-        final var workerDao = jdbi.onDemand(WorkerDao.class);
+    public static TestData seed(final DataSource ds) {
+        final var topicDao = new TopicDao(ds);
+        final var consumerGroupDao = new ConsumerGroupDao(ds);
+        final var subscriptionService = new SubscriptionService(ds);
+        final var subscriptionOffsetDao = new SubscriptionOffsetDao(ds);
+        final var workerDao = new WorkerDao(ds);
 
         // Create the topics
         final var topicA = topicDao.find(topicDao.create(TENANT_1, TOPIC_A, DEFAULT_PARTITIONS)).orElseThrow();
@@ -65,7 +65,7 @@ public record TestData(Topic topic,
         subscriptionService.subscribe(TENANT_2, CONSUMER_GROUP_A, TOPIC_D);
         subscriptionService.subscribe(TENANT_2, CONSUMER_GROUP_B, TOPIC_C);
         subscriptionService.subscribe(TENANT_2, CONSUMER_GROUP_B, TOPIC_D);
-        final var subscriptions = jdbi.onDemand(SubscriptionDao.class).findAll(100, 0);
+        final var subscriptions = new SubscriptionDao(ds).findAll(100, 0);
         final var firstSubscription = subscriptions.getFirst();
         final var subscriptionOffset = subscriptionOffsetDao.findAll(firstSubscription.id()).getFirst();
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,18 +59,6 @@
                 <version>6.3.0</version>
             </dependency>
 
-            <!-- JDBI3 -->
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-core</artifactId>
-                <version>3.49.5</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jdbi</groupId>
-                <artifactId>jdbi3-sqlobject</artifactId>
-                <version>3.49.5</version>
-            </dependency>
 
             <!-- DATABASE DRIVERS (MYSQL) -->
             <dependency>


### PR DESCRIPTION
## Summary
- replace `JdbcUtil` static helpers with `BaseDao` abstract class
- move `RowMapper` to its own file
- refactor DAOs to extend `BaseDao`

## Testing
- `mvn -q -DskipTests install` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6882508cc79c832fa02bcc8b296a2da7