### PR TITLE
Limit stats refresh on worker check-in

### DIFF
--- a/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
+++ b/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
@@ -11,6 +11,7 @@ public record ConsumerGroup(
         double heartbeatIntervalMax,
         double heartbeatDeadlineMultiplier,
         double heartbeatTargetQPS,
+        int statisticsRefreshInterval,
         int releaseDeadline,
         int activePartitions,
         int activeWorkers,

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
@@ -17,6 +17,7 @@ public class ConsumerGroupMapper implements RowMapper<ConsumerGroup> {
                 rs.getDouble("heartbeat_interval_max"),
                 rs.getDouble("heartbeat_deadline_multiplier"),
                 rs.getDouble("heartbeat_target_qps"),
+                rs.getInt("statistics_refresh_interval"),
                 rs.getInt("release_deadline"),
                 rs.getInt("active_partitions"),
                 rs.getInt("active_workers"),

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE consumer_groups (
     heartbeat_interval_max          DOUBLE NOT NULL DEFAULT 1000.00,
     heartbeat_deadline_multiplier   DOUBLE NOT NULL DEFAULT 5.0,
     heartbeat_target_qps            DOUBLE NOT NULL DEFAULT 10.0,
+    statistics_refresh_interval     INT NOT NULL DEFAULT 5,
     release_deadline                INT NOT NULL DEFAULT 10,
     active_partitions               INT NOT NULL DEFAULT 0,
     active_workers                  INT NOT NULL DEFAULT 0,

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE consumer_groups (
     heartbeat_interval_max          DOUBLE NOT NULL DEFAULT 1000.00,
     heartbeat_deadline_multiplier   DOUBLE NOT NULL DEFAULT 5.0,
     heartbeat_target_qps            DOUBLE NOT NULL DEFAULT 10.0,
-    statistics_refresh_interval     INT NOT NULL DEFAULT 5,
+    statistics_refresh_interval     INT NOT NULL DEFAULT 3,
     release_deadline                INT NOT NULL DEFAULT 10,
     active_partitions               INT NOT NULL DEFAULT 0,
     active_workers                  INT NOT NULL DEFAULT 0,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers_check_in__update_stats.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers_check_in__update_stats.sql
@@ -8,49 +8,57 @@ CREATE PROCEDURE sp_workers_check_in__update_stats(
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN RESIGNAL; END;
 
-    -- ACTIVE WORKERS
-    SELECT COUNT(1), COALESCE(SUM(weight), 0)
-        INTO p_active_workers, p_active_workers_weight
-        FROM workers
-       WHERE consumer_group_id = p_consumer_group_id
-         AND heartbeat_deadline > CURRENT_TIMESTAMP(3);
-
-    -- ACTIVE PARTITIONS (where high_watermark > committed_offset)
-    SELECT COUNT(1)
-      INTO p_active_partitions
-      FROM subscriptions s
-      JOIN subscription_offsets so ON s.id = so.subscription_id
-      JOIN partitions p ON so.partition_id = p.id
-     WHERE so.committed_offset < p.high_watermark
-       AND s.consumer_group_id = p_consumer_group_id;
-
-    -- Get heartbeat configuration values from consumer_groups, including the last statistics update time
+    -- Get heartbeat configuration values from consumer_groups
     SELECT heartbeat_interval_default,
            heartbeat_target_qps,
            heartbeat_interval_min,
            heartbeat_interval_max,
            statistics_refresh_interval,
+           active_partitions,
+           active_workers,
+           active_workers_weight,
            last_updated
       INTO p_heartbeat_interval,
            @target_qps,
            @interval_min,
            @interval_max,
            @stats_refresh_interval,
+           p_active_partitions,
+           p_active_workers,
+           p_active_workers_weight,
            @stats_last_updated
       FROM consumer_groups
      WHERE id = p_consumer_group_id;
 
-    -- Calculate adaptive heartbeat interval based on heartbeat_interval_default
-    -- Use the configurable heartbeat_target_qps
-    -- This controls the ideal cluster-wide check-ins per second
-    SET p_heartbeat_interval = GREATEST(p_heartbeat_interval, p_active_workers / @target_qps);
-    
-    -- Apply min and max constraints to the heartbeat interval
-    SET p_heartbeat_interval = GREATEST(p_heartbeat_interval, @interval_min);
-    SET p_heartbeat_interval = LEAST(p_heartbeat_interval, @interval_max);
-
     -- Update the stats in the consumer_groups table if they are stale
     IF TIMESTAMPDIFF(SECOND, @stats_last_updated, CURRENT_TIMESTAMP(3)) >= @stats_refresh_interval THEN
+
+        -- ACTIVE WORKERS
+        SELECT COUNT(1), COALESCE(SUM(weight), 0)
+            INTO p_active_workers, p_active_workers_weight
+            FROM workers
+           WHERE consumer_group_id = p_consumer_group_id
+             AND heartbeat_deadline > CURRENT_TIMESTAMP(3);
+
+        -- ACTIVE PARTITIONS (where high_watermark > committed_offset)
+        SELECT COUNT(1)
+          INTO p_active_partitions
+          FROM subscriptions s
+          JOIN subscription_offsets so ON s.id = so.subscription_id
+          JOIN partitions p ON so.partition_id = p.id
+         WHERE s.consumer_group_id = p_consumer_group_id
+           AND so.committed_offset < p.high_watermark;
+
+        -- Calculate adaptive heartbeat interval based on heartbeat_interval_default
+        -- Use the configurable heartbeat_target_qps
+        -- This controls the ideal cluster-wide check-ins per second
+        SET p_heartbeat_interval = GREATEST(p_heartbeat_interval, p_active_workers / @target_qps);
+
+        -- Apply min and max constraints to the heartbeat interval
+        SET p_heartbeat_interval = GREATEST(p_heartbeat_interval, @interval_min);
+        SET p_heartbeat_interval = LEAST(p_heartbeat_interval, @interval_max);
+
+        -- Update consumer group statistics
         UPDATE consumer_groups
            SET active_workers        = p_active_workers,
                active_workers_weight = p_active_workers_weight,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers_check_in__update_stats.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers_check_in__update_stats.sql
@@ -24,9 +24,19 @@ BEGIN
      WHERE so.committed_offset < p.high_watermark
        AND s.consumer_group_id = p_consumer_group_id;
 
-    -- Get heartbeat configuration values from consumer_groups
-    SELECT heartbeat_interval_default, heartbeat_target_qps, heartbeat_interval_min, heartbeat_interval_max
-      INTO p_heartbeat_interval, @target_qps, @interval_min, @interval_max
+    -- Get heartbeat configuration values from consumer_groups, including the last statistics update time
+    SELECT heartbeat_interval_default,
+           heartbeat_target_qps,
+           heartbeat_interval_min,
+           heartbeat_interval_max,
+           statistics_refresh_interval,
+           last_updated
+      INTO p_heartbeat_interval,
+           @target_qps,
+           @interval_min,
+           @interval_max,
+           @stats_refresh_interval,
+           @stats_last_updated
       FROM consumer_groups
      WHERE id = p_consumer_group_id;
 
@@ -39,12 +49,14 @@ BEGIN
     SET p_heartbeat_interval = GREATEST(p_heartbeat_interval, @interval_min);
     SET p_heartbeat_interval = LEAST(p_heartbeat_interval, @interval_max);
 
-    -- Update the stats in the consumer_groups table
-    UPDATE consumer_groups
-       SET active_workers        = p_active_workers,
-           active_workers_weight = p_active_workers_weight,
-          active_partitions      = p_active_partitions,
-          last_updated             = CURRENT_TIMESTAMP(3)
-    WHERE id = p_consumer_group_id;
+    -- Update the stats in the consumer_groups table if they are stale
+    IF TIMESTAMPDIFF(SECOND, @stats_last_updated, CURRENT_TIMESTAMP(3)) >= @stats_refresh_interval THEN
+        UPDATE consumer_groups
+           SET active_workers        = p_active_workers,
+               active_workers_weight = p_active_workers_weight,
+               active_partitions     = p_active_partitions,
+               last_updated          = CURRENT_TIMESTAMP(3)
+        WHERE id = p_consumer_group_id;
+    END IF;
 
 END;


### PR DESCRIPTION
## Summary
- add `statistics_refresh_interval` column to `consumer_groups`
- update consumer group domain and mapper for new field
- only refresh consumer group statistics when stale

## Testing
- `mvn -q -DskipTests install` *(fails: Plugin resolution could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68894040b864832f874b08da2d4fbecf