### PR TITLE
Refine worker heartbeat update

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers__heartbeat.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_workers__heartbeat.sql
@@ -13,7 +13,6 @@ BEGIN
     IF v_exists THEN
         -- UPDATE WORKER
         UPDATE workers w
-          JOIN subscriptions s ON s.id = w.subscription_id
            SET w.weight = p_weight,
                w.heartbeat_detected_at = CURRENT_TIMESTAMP(3)
          WHERE w.id = p_worker_id;


### PR DESCRIPTION
## Summary
- remove unnecessary JOIN in `sp_workers__heartbeat` to avoid misusing inner join

## Testing
- `mvn -pl boxy-db -am test`

------
https://chatgpt.com/codex/tasks/task_e_688de428d2c0832fb6af855e45fe9872