### PR TITLE
refactor namespace path handling

### DIFF
--- a/boxy-core/src/main/java/boxy/core/repository/NamespaceRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/NamespaceRepository.java
@@ -33,7 +33,11 @@ public final class NamespaceRepository extends BaseRepository {
     }
 
     public Optional<Namespace> find(String path) {
-        return queryOne("SELECT * FROM namespaces WHERE path = ?", NAMESPACE_MAPPER, path);
+        return queryOne("""
+                        SELECT n.*, fn_namespace_path(n.id) AS path
+                          FROM namespaces n
+                         WHERE n.id = fn_resolve_namespace_id(?)
+                        """, NAMESPACE_MAPPER, path);
     }
 }
 

--- a/boxy-core/src/main/java/boxy/core/repository/PartitionRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/PartitionRepository.java
@@ -19,8 +19,7 @@ public final class PartitionRepository extends BaseRepository {
                         SELECT p.*
                           FROM partitions p
                           JOIN topics t ON p.topic_id = t.id
-                          JOIN namespaces n ON t.namespace_id = n.id
-                         WHERE n.path = ?
+                         WHERE t.namespace_id = fn_resolve_namespace_id(?)
                            AND t.name = ?
                            AND p.partition_number = ?
                         """,

--- a/boxy-core/src/main/java/boxy/core/repository/SubscriptionTopicRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/SubscriptionTopicRepository.java
@@ -23,9 +23,8 @@ public final class SubscriptionTopicRepository extends BaseRepository {
                         SELECT st.* FROM subscription_topics st
                             JOIN subscriptions s ON st.subscription_id = s.id
                             JOIN topics t ON st.topic_id = t.id
-                            JOIN namespaces n ON t.namespace_id = n.id
                             WHERE s.name = ? AND
-                                  n.path = ? AND
+                                  t.namespace_id = fn_resolve_namespace_id(?) AND
                                   t.name = ?
                         """, SUBSCRIPTION_TOPIC_MAPPER,
                 subscription, path, topic);

--- a/boxy-core/src/main/java/boxy/core/repository/TopicRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/TopicRepository.java
@@ -26,8 +26,7 @@ public final class TopicRepository extends BaseRepository {
         return queryOne("""
                         SELECT t.*
                           FROM topics t
-                          JOIN namespaces n ON t.namespace_id = n.id
-                         WHERE n.path = ?
+                         WHERE t.namespace_id = fn_resolve_namespace_id(?)
                            AND t.name = ?
                         """,
                 TOPIC_MAPPER, path, name);

--- a/boxy-db/src/main/resources/db/changelog/mysql/fn/fn_namespace_path.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/fn/fn_namespace_path.sql
@@ -1,0 +1,28 @@
+-- FUNCTION TO BUILD THE PATH OF A NAMESPACE GIVEN ITS ID
+CREATE FUNCTION fn_namespace_path(p_id BIGINT)
+RETURNS VARCHAR(1024)
+DETERMINISTIC
+BEGIN
+    DECLARE v_name VARCHAR(255);
+    DECLARE v_parent BIGINT;
+    DECLARE v_path VARCHAR(1024) DEFAULT '';
+    DECLARE v_id BIGINT;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_id = NULL;
+
+    SET v_id = p_id;
+
+    WHILE v_id IS NOT NULL DO
+        SELECT name, parent_id INTO v_name, v_parent FROM namespaces WHERE id = v_id;
+        IF v_name IS NULL THEN
+            RETURN NULL;
+        END IF;
+        IF v_path = '' THEN
+            SET v_path = v_name;
+        ELSE
+            SET v_path = CONCAT(v_name, '/', v_path);
+        END IF;
+        SET v_id = v_parent;
+    END WHILE;
+
+    RETURN v_path;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/fn/fn_resolve_namespace_id.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/fn/fn_resolve_namespace_id.sql
@@ -1,0 +1,34 @@
+-- FUNCTION TO RESOLVE A NAMESPACE ID FROM ITS PATH
+CREATE FUNCTION fn_resolve_namespace_id(p_path VARCHAR(1024))
+RETURNS BIGINT
+DETERMINISTIC
+BEGIN
+    DECLARE v_parent_id BIGINT;
+    DECLARE v_id BIGINT;
+    DECLARE v_segment VARCHAR(255);
+    DECLARE v_pos INT DEFAULT 1;
+    DECLARE v_next INT;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_id = NULL;
+
+    IF p_path IS NULL OR p_path = '' THEN
+        RETURN NULL;
+    END IF;
+
+    SET v_parent_id = NULL;
+    SET v_next = LOCATE('/', p_path, v_pos);
+
+    WHILE v_next > 0 DO
+        SET v_segment = SUBSTRING(p_path, v_pos, v_next - v_pos);
+        SELECT id INTO v_id FROM namespaces WHERE parent_id <=> v_parent_id AND name = v_segment;
+        IF v_id IS NULL THEN
+            RETURN NULL;
+        END IF;
+        SET v_parent_id = v_id;
+        SET v_pos = v_next + 1;
+        SET v_next = LOCATE('/', p_path, v_pos);
+    END WHILE;
+
+    SET v_segment = SUBSTRING(p_path, v_pos);
+    SELECT id INTO v_id FROM namespaces WHERE parent_id <=> v_parent_id AND name = v_segment;
+    RETURN v_id;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
@@ -17,6 +17,14 @@
                  relativeToChangelogFile="true"
                  splitStatements="false"
                  stripComments="false"/>
+        <sqlFile path="fn/fn_resolve_namespace_id.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="false"
+                 stripComments="false"/>
+        <sqlFile path="fn/fn_namespace_path.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="false"
+                 stripComments="false"/>
 
         <!-- SP: WORKERS -->
         <sqlFile path="sp/sp_workers__delete.sql"

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -2,10 +2,8 @@ CREATE TABLE namespaces (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
     name             VARCHAR(255)   NOT NULL,
     parent_id        BIGINT         NULL,
-    path             VARCHAR(1024)  NOT NULL,
     created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     last_modified_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-    CONSTRAINT u_namespaces__path UNIQUE (path),
     CONSTRAINT u_namespaces__parent UNIQUE (parent_id, name),
     FOREIGN KEY (parent_id) REFERENCES namespaces(id) ON DELETE CASCADE
 ) ENGINE=InnoDB
@@ -139,11 +137,12 @@ CREATE TABLE events (
     COMMENT='Append-only event store per partition; JSON payloads in sequence order';
 
 CREATE TABLE topics_cache (
+  path_hash    BINARY(16)    NOT NULL,
   path         VARCHAR(1024) NOT NULL,
   topic        VARCHAR(255)  NOT NULL,
   topic_id     BIGINT        NOT NULL,
   partitions   INT NOT NULL,
-  PRIMARY KEY (path, topic)
+  PRIMARY KEY (path_hash, topic)
 ) ENGINE=MEMORY;
 
 -- ========================================================

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_namespaces__create.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_namespaces__create.sql
@@ -3,17 +3,14 @@ CREATE PROCEDURE sp_namespaces__create(
     IN p_name        VARCHAR(255))
 BEGIN
     DECLARE v_parent_id BIGINT;
-    DECLARE v_path VARCHAR(1024);
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN RESIGNAL; END;
 
     IF p_parent_path IS NULL OR p_parent_path = '' THEN
         SET v_parent_id = NULL;
-        SET v_path = p_name;
     ELSE
-        SELECT id INTO v_parent_id FROM namespaces WHERE path = p_parent_path;
-        SET v_path = CONCAT(p_parent_path, '/', p_name);
+        SET v_parent_id = fn_resolve_namespace_id(p_parent_path);
     END IF;
 
-    INSERT INTO namespaces(name, parent_id, path) VALUES (p_name, v_parent_id, v_path);
+    INSERT INTO namespaces(name, parent_id) VALUES (p_name, v_parent_id);
     SELECT LAST_INSERT_ID() AS id;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_namespaces__delete.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_namespaces__delete.sql
@@ -1,7 +1,10 @@
 CREATE PROCEDURE sp_namespaces__delete(
     IN p_path VARCHAR(1024))
 BEGIN
+    DECLARE v_id BIGINT;
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN RESIGNAL; END;
-    DELETE FROM namespaces WHERE path = p_path;
+    SET v_id = fn_resolve_namespace_id(p_path);
+    IF v_id IS NOT NULL THEN
+        DELETE FROM namespaces WHERE id = v_id;
+    END IF;
 END;
-

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__cache_get.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__cache_get.sql
@@ -7,22 +7,26 @@ CREATE PROCEDURE sp_topics__cache_get(
 BEGIN
   -- 1) on NOT FOUND, reset OUTs then CONTINUE to next stmt
   DECLARE v_namespace_id BIGINT;
+  DECLARE v_path_hash BINARY(16);
   DECLARE CONTINUE HANDLER FOR NOT FOUND
   BEGIN
     SET p_topic_id   = NULL;
     SET p_partitions = NULL;
   END;
 
+  SET v_path_hash = UNHEX(MD5(p_path));
+
   -- 2) try the cache
   SELECT topic_id, partitions
     INTO p_topic_id, p_partitions
     FROM topics_cache
-   WHERE path = p_path
-     AND topic  = p_topic;
+   WHERE path_hash = v_path_hash
+     AND topic     = p_topic
+     AND path      = p_path;
 
   IF p_topic_id IS NULL THEN
-    -- cache miss: fetch the “real” value
-    SELECT id INTO v_namespace_id FROM namespaces WHERE path = p_path;
+    -- cache miss: fetch the "real" value
+    SET v_namespace_id = fn_resolve_namespace_id(p_path);
 
     SELECT id, partitions
       INTO p_topic_id, p_partitions
@@ -31,9 +35,10 @@ BEGIN
        AND name         = p_topic;
 
     IF p_topic_id IS NOT NULL THEN
-      INSERT INTO topics_cache (path, topic, topic_id, partitions)
-        VALUES (p_path, p_topic, p_topic_id, p_partitions)
+      INSERT INTO topics_cache (path_hash, path, topic, topic_id, partitions)
+        VALUES (v_path_hash, p_path, p_topic, p_topic_id, p_partitions)
       ON DUPLICATE KEY UPDATE
+        path       = VALUES(path),
         topic_id   = VALUES(topic_id),
         partitions = VALUES(partitions);
     END IF;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__create.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__create.sql
@@ -9,7 +9,7 @@ BEGIN
 
     START TRANSACTION;
         -- RESOLVE THE NAMESPACE ID
-        SELECT id INTO v_namespace_id FROM namespaces WHERE path = p_path;
+        SET v_namespace_id = fn_resolve_namespace_id(p_path);
 
         -- CREATE THE TOPIC
         INSERT INTO topics (namespace_id, name, partitions) VALUES (v_namespace_id, p_name, p_partitions);

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__delete.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__delete.sql
@@ -5,7 +5,7 @@ BEGIN
     DECLARE v_namespace_id BIGINT;
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN RESIGNAL; END;
     -- RESOLVE THE NAMESPACE ID
-    SELECT id INTO v_namespace_id FROM namespaces WHERE path = p_path;
+    SET v_namespace_id = fn_resolve_namespace_id(p_path);
     -- DELETE
     DELETE FROM topics WHERE namespace_id = v_namespace_id AND name = p_name;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__subscribe.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__subscribe.sql
@@ -11,7 +11,7 @@ BEGIN
 
     START TRANSACTION;
         -- RESOLVE THE NAMESPACE ID
-        SELECT id INTO v_namespace_id FROM namespaces WHERE path = p_path;
+        SET v_namespace_id = fn_resolve_namespace_id(p_path);
 
         -- RESOLVE THE TOPIC ID
         SELECT id INTO v_topic_id FROM topics WHERE namespace_id = v_namespace_id AND name = p_topic;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__unsubscribe.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_topics__unsubscribe.sql
@@ -9,7 +9,7 @@ BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN RESIGNAL; END;
 
     -- RESOLVE THE NAMESPACE ID
-    SELECT id INTO v_namespace_id FROM namespaces WHERE path = p_path;
+    SET v_namespace_id = fn_resolve_namespace_id(p_path);
 
     -- RESOLVE THE TOPIC ID
     SELECT id INTO v_topic_id FROM topics WHERE namespace_id = v_namespace_id AND name = p_topic;


### PR DESCRIPTION
## Summary
- store namespaces using parent-child relationships and resolve full paths with new helper functions
- hash namespace path in topics_cache for fast topic lookup without oversized indexes
- update repositories and procedures to use fn_resolve_namespace_id instead of materialized paths

## Testing
- `mvn -q -e test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_688f34d2c4f4832f852bd99cd2ac7bfa