### PR TITLE
feat: centralize consumer group config in cluster policy tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ erDiagram
   distributing the start position when acquiring leases.
 - **consumers**: registers each consumer’s `consumer_group_id`, `weight`, and `heartbeat_detected_at`.
 - **leases**: one row per `cursor` when a consumer holds a lease, with `state` indicating whether it's 'ACTIVE' or 'RELEASING'.
-- **consumer_groups**: stores configuration and precomputed statistics for each consumer group.
+- **consumer_groups**: stores precomputed statistics for each consumer group.
+- **heartbeat_policies**, **lease_policies**, **metrics_policies**: singleton tables providing cluster-wide configuration.
 - **topics_cache**: in-memory table for quick topic lookups.
 
 ### Consumer Group Statistics
@@ -107,15 +108,24 @@ The `consumer_groups` table stores precomputed statistics that are updated with 
 - **active_consumers**: Count of consumers with valid heartbeats. 
 - **active_consumers_weight**: Sum of weights of all active consumers in the consumer group.
 - **last_modified_at**: Timestamp of the last statistics update.
-- **lease_release_period**: Configurable period (in seconds) for how long a lease remains in the 'RELEASING' state before being deleted.
 
 These statistics are used for:
 
 1. **Fair Share Calculation**: The ideal share of leases for each consumer is calculated as `(consumer_weight / active_consumers_weight) * active_partitions`.
 2. **Adaptive Heartbeat Intervals**: The heartbeat interval is adjusted based on the number of active consumers to maintain a target QPS (queries per second) for the cluster.
-3. **Garbage Collection**: The lease_release_period determines how long a lease remains in the 'RELEASING' state before being deleted.
+3. **Garbage Collection**: The cluster's lease policy (`lease_release_period`) determines how long a lease remains in the 'RELEASING' state before being deleted.
 
 Precomputing these statistics reduces the need for expensive queries during consumer check-ins and ensures consistent fair share calculations across all consumers.
+
+### Cluster Policies
+
+The following tables define cluster-wide defaults and each contains exactly one row:
+
+- `heartbeat_policies`: `heartbeat_deadline_multiplier`, `heartbeat_interval_baseline`, `heartbeat_interval_limit`, `heartbeat_target_qps`
+- `lease_policies`: `active_consumers_limit`, `lease_release_period`
+- `metrics_policies`: `metrics_refresh_interval`
+
+Operators can adjust these records to tune cluster behavior.
 
 ## Domain Classes
 
@@ -347,9 +357,6 @@ You can configure various aspects of Boxy:
 BoxyConsumerGroup consumerGroup = BoxyConsumerGroup.builder()
     .dataSource(dataSource)
     .name("order-processor")
-    .heartbeatIntervalBaseline(3.0) // Default heartbeat interval in seconds
-    .heartbeatTargetQPS(10.0)      // Target heartbeats per second for the cluster
-    .leaseReleasePeriod(10)           // Seconds to wait before cleaning up releasing leases
     .build();
 
 BoxyConsumer consumer = consumerGroup.createConsumer(BoxyConsumer.builder()
@@ -357,6 +364,8 @@ BoxyConsumer consumer = consumerGroup.createConsumer(BoxyConsumer.builder()
     .weight(2)                     // Higher weight gets proportionally more partitions
     .build());
 ```
+
+Cluster-wide heartbeat, lease, and metrics settings can be adjusted by updating the `heartbeat_policies`, `lease_policies`, and `metrics_policies` tables.
 
 ## FAQ
 

--- a/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
+++ b/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
@@ -5,16 +5,9 @@ import java.time.Instant;
 public record ConsumerGroup(
         long id,
         String name,
-        double heartbeatDeadlineMultiplier,
-        double heartbeatIntervalBaseline,
         double heartbeatInterval,
-        double heartbeatIntervalLimit,
-        double heartbeatTargetQPS,
-        int metricsRefreshInterval,
-        int leaseReleasePeriod,
         int activePartitions,
         int activeConsumers,
-        int activeConsumersLimit,
         double activeConsumersWeight,
         Instant lastModifiedAt) {
 }

--- a/boxy-core/src/main/java/boxy/core/domain/HeartbeatPolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/HeartbeatPolicy.java
@@ -1,7 +1,6 @@
 package boxy.core.domain;
 
 public record HeartbeatPolicy(
-        int id,
         double heartbeatDeadlineMultiplier,
         double heartbeatIntervalBaseline,
         double heartbeatIntervalLimit,

--- a/boxy-core/src/main/java/boxy/core/domain/HeartbeatPolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/HeartbeatPolicy.java
@@ -1,0 +1,9 @@
+package boxy.core.domain;
+
+public record HeartbeatPolicy(
+        int id,
+        double heartbeatDeadlineMultiplier,
+        double heartbeatIntervalBaseline,
+        double heartbeatIntervalLimit,
+        double heartbeatTargetQps) {
+}

--- a/boxy-core/src/main/java/boxy/core/domain/LeasePolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/LeasePolicy.java
@@ -1,7 +1,6 @@
 package boxy.core.domain;
 
 public record LeasePolicy(
-        int id,
         int activeConsumersLimit,
         int leaseReleasePeriod) {
 }

--- a/boxy-core/src/main/java/boxy/core/domain/LeasePolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/LeasePolicy.java
@@ -1,0 +1,7 @@
+package boxy.core.domain;
+
+public record LeasePolicy(
+        int id,
+        int activeConsumersLimit,
+        int leaseReleasePeriod) {
+}

--- a/boxy-core/src/main/java/boxy/core/domain/MetricsPolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/MetricsPolicy.java
@@ -1,0 +1,6 @@
+package boxy.core.domain;
+
+public record MetricsPolicy(
+        int id,
+        int metricsRefreshInterval) {
+}

--- a/boxy-core/src/main/java/boxy/core/domain/MetricsPolicy.java
+++ b/boxy-core/src/main/java/boxy/core/domain/MetricsPolicy.java
@@ -1,6 +1,5 @@
 package boxy.core.domain;
 
 public record MetricsPolicy(
-        int id,
         int metricsRefreshInterval) {
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/CheckInResultMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/CheckInResultMapper.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 
 public class CheckInResultMapper implements RowMapper<CheckInResult> {
     @Override
-    public CheckInResult map(ResultSet rs) throws SQLException {
+    public CheckInResult map(final ResultSet rs) throws SQLException {
         return new CheckInResult(
                 rs.getDouble("heartbeat_interval"),
                 rs.getTimestamp("heartbeat_deadline").toInstant(),

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
@@ -11,16 +11,9 @@ public class ConsumerGroupMapper implements RowMapper<ConsumerGroup> {
         return new ConsumerGroup(
                 rs.getLong("id"),
                 rs.getString("name"),
-                rs.getDouble("heartbeat_deadline_multiplier"),
-                rs.getDouble("heartbeat_interval_baseline"),
                 rs.getDouble("heartbeat_interval"),
-                rs.getDouble("heartbeat_interval_limit"),
-                rs.getDouble("heartbeat_target_qps"),
-                rs.getInt("metrics_refresh_interval"),
-                rs.getInt("lease_release_period"),
                 rs.getInt("active_partitions"),
                 rs.getInt("active_consumers"),
-                rs.getInt("active_consumers_limit"),
                 rs.getDouble("active_consumers_weight"),
                 rs.getTimestamp("last_modified_at").toInstant());
     }

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class ConsumerGroupMapper implements RowMapper<ConsumerGroup> {
     @Override
-    public ConsumerGroup map(ResultSet rs) throws SQLException {
+    public ConsumerGroup map(final ResultSet rs) throws SQLException {
         return new ConsumerGroup(
                 rs.getLong("id"),
                 rs.getString("name"),

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class ConsumerMapper implements RowMapper<Consumer> {
     @Override
-    public Consumer map(ResultSet rs) throws SQLException {
+    public Consumer map(final ResultSet rs) throws SQLException {
         return new Consumer(
                 rs.getString("id"),
                 rs.getLong("consumer_group_id"),

--- a/boxy-core/src/main/java/boxy/core/mapper/CursorMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/CursorMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class CursorMapper implements RowMapper<Cursor> {
     @Override
-    public Cursor map(ResultSet rs) throws SQLException {
+    public Cursor map(final ResultSet rs) throws SQLException {
         return new Cursor(
                 rs.getLong("id"),
                 rs.getLong("subscription_id"),

--- a/boxy-core/src/main/java/boxy/core/mapper/HeartbeatPolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/HeartbeatPolicyMapper.java
@@ -1,0 +1,18 @@
+package boxy.core.mapper;
+
+import boxy.core.domain.HeartbeatPolicy;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class HeartbeatPolicyMapper implements RowMapper<HeartbeatPolicy> {
+    @Override
+    public HeartbeatPolicy map(ResultSet rs) throws SQLException {
+        return new HeartbeatPolicy(
+                rs.getInt("id"),
+                rs.getDouble("heartbeat_deadline_multiplier"),
+                rs.getDouble("heartbeat_interval_baseline"),
+                rs.getDouble("heartbeat_interval_limit"),
+                rs.getDouble("heartbeat_target_qps"));
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/mapper/HeartbeatPolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/HeartbeatPolicyMapper.java
@@ -7,9 +7,8 @@ import java.sql.SQLException;
 
 public class HeartbeatPolicyMapper implements RowMapper<HeartbeatPolicy> {
     @Override
-    public HeartbeatPolicy map(ResultSet rs) throws SQLException {
+    public HeartbeatPolicy map(final ResultSet rs) throws SQLException {
         return new HeartbeatPolicy(
-                rs.getInt("id"),
                 rs.getDouble("heartbeat_deadline_multiplier"),
                 rs.getDouble("heartbeat_interval_baseline"),
                 rs.getDouble("heartbeat_interval_limit"),

--- a/boxy-core/src/main/java/boxy/core/mapper/IdMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/IdMapper.java
@@ -5,7 +5,7 @@ import java.sql.SQLException;
 
 public class IdMapper implements RowMapper<Long> {
     @Override
-    public Long map(ResultSet rs) throws SQLException {
+    public Long map(final ResultSet rs) throws SQLException {
         return rs.getLong(1);
     }
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/LeaseMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/LeaseMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class LeaseMapper implements RowMapper<Lease> {
     @Override
-    public Lease map(ResultSet rs) throws SQLException {
+    public Lease map(final ResultSet rs) throws SQLException {
         return new Lease(
                 rs.getLong("cursor_id"),
                 rs.getString("consumer_id"),

--- a/boxy-core/src/main/java/boxy/core/mapper/LeasePolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/LeasePolicyMapper.java
@@ -1,0 +1,16 @@
+package boxy.core.mapper;
+
+import boxy.core.domain.LeasePolicy;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class LeasePolicyMapper implements RowMapper<LeasePolicy> {
+    @Override
+    public LeasePolicy map(ResultSet rs) throws SQLException {
+        return new LeasePolicy(
+                rs.getInt("id"),
+                rs.getInt("active_consumers_limit"),
+                rs.getInt("lease_release_period"));
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/mapper/LeasePolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/LeasePolicyMapper.java
@@ -7,9 +7,8 @@ import java.sql.SQLException;
 
 public class LeasePolicyMapper implements RowMapper<LeasePolicy> {
     @Override
-    public LeasePolicy map(ResultSet rs) throws SQLException {
+    public LeasePolicy map(final ResultSet rs) throws SQLException {
         return new LeasePolicy(
-                rs.getInt("id"),
                 rs.getInt("active_consumers_limit"),
                 rs.getInt("lease_release_period"));
     }

--- a/boxy-core/src/main/java/boxy/core/mapper/MetricsPolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/MetricsPolicyMapper.java
@@ -7,9 +7,7 @@ import java.sql.SQLException;
 
 public class MetricsPolicyMapper implements RowMapper<MetricsPolicy> {
     @Override
-    public MetricsPolicy map(ResultSet rs) throws SQLException {
-        return new MetricsPolicy(
-                rs.getInt("id"),
-                rs.getInt("metrics_refresh_interval"));
+    public MetricsPolicy map(final ResultSet rs) throws SQLException {
+        return new MetricsPolicy(rs.getInt("metrics_refresh_interval"));
     }
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/MetricsPolicyMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/MetricsPolicyMapper.java
@@ -1,0 +1,15 @@
+package boxy.core.mapper;
+
+import boxy.core.domain.MetricsPolicy;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class MetricsPolicyMapper implements RowMapper<MetricsPolicy> {
+    @Override
+    public MetricsPolicy map(ResultSet rs) throws SQLException {
+        return new MetricsPolicy(
+                rs.getInt("id"),
+                rs.getInt("metrics_refresh_interval"));
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/mapper/NamespaceMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/NamespaceMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class NamespaceMapper implements RowMapper<Namespace> {
     @Override
-    public Namespace map(ResultSet rs) throws SQLException {
+    public Namespace map(final ResultSet rs) throws SQLException {
         return new Namespace(
                 rs.getLong("id"),
                 rs.getObject("parent_id", Long.class),

--- a/boxy-core/src/main/java/boxy/core/mapper/PartitionMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/PartitionMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class PartitionMapper implements RowMapper<Partition> {
     @Override
-    public Partition map(ResultSet rs) throws SQLException {
+    public Partition map(final ResultSet rs) throws SQLException {
         return new Partition(
                 rs.getLong("id"),
                 rs.getLong("topic_id"),

--- a/boxy-core/src/main/java/boxy/core/mapper/SubscriptionMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/SubscriptionMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class SubscriptionMapper implements RowMapper<Subscription> {
     @Override
-    public Subscription map(ResultSet rs) throws SQLException {
+    public Subscription map(final ResultSet rs) throws SQLException {
         return new Subscription(
                 rs.getLong("id"),
                 rs.getLong("consumer_group_id"),

--- a/boxy-core/src/main/java/boxy/core/mapper/TopicMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/TopicMapper.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class TopicMapper implements RowMapper<Topic> {
     @Override
-    public Topic map(ResultSet rs) throws SQLException {
+    public Topic map(final ResultSet rs) throws SQLException {
         return new Topic(
                 rs.getLong("id"),
                 rs.getLong("namespace_id"),

--- a/boxy-core/src/main/java/boxy/core/repository/BaseRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/BaseRepository.java
@@ -18,25 +18,19 @@ public abstract class BaseRepository {
 
     protected final DataSource ds;
 
-    protected BaseRepository(DataSource ds) {
+    protected BaseRepository(final DataSource ds) {
         this.ds = ds;
     }
 
-    protected <T> Optional<T> queryOne(final String sql,
-                                       final RowMapper<T> mapper,
-                                       final Object... parameters) {
+    protected <T> Optional<T> queryOne(final String sql, final RowMapper<T> mapper, final Object... parameters) {
         return execute(sql, ps -> {
             try (final var rs = ps.executeQuery()) {
-                return rs.next() ?
-                        Optional.of(mapper.map(rs)) :
-                        Optional.empty();
+                return rs.next() ? Optional.of(mapper.map(rs)) : Optional.empty();
             }
         }, parameters);
     }
 
-    protected <T> List<T> query(final String sql,
-                                final RowMapper<T> mapper,
-                                final Object... parameters) {
+    protected <T> List<T> query(final String sql, final RowMapper<T> mapper, final Object... parameters) {
         return execute(sql, ps -> {
             try (final var rs = ps.executeQuery()) {
                 final var results = new ArrayList<T>();
@@ -48,20 +42,17 @@ public abstract class BaseRepository {
         }, parameters);
     }
 
-    protected int update(final String sql,
-                         final Object... parameters) {
+    protected int update(final String sql, final Object... parameters) {
         return execute(sql, PreparedStatement::executeUpdate, parameters);
     }
 
-    private <T> T execute(final String sql,
-                          final SQLFunction<PreparedStatement, T> function,
-                          final Object... parameters) {
+    private <T> T execute(final String sql, final SQLFunction<PreparedStatement, T> fn, final Object... parameters) {
         try (final var connection = ds.getConnection();
              final var statement = connection.prepareStatement(sql)) {
             for (var i = 0; i < parameters.length; i++) {
                 statement.setObject(i + 1, parameters[i]);
             }
-            return function.apply(statement);
+            return fn.apply(statement);
         } catch (SQLException e) {
             throw new DataAccessException(e);
         }

--- a/boxy-core/src/main/java/boxy/core/repository/ConsumerGroupRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/ConsumerGroupRepository.java
@@ -14,31 +14,31 @@ public final class ConsumerGroupRepository extends BaseRepository {
     private static final ConsumerGroupMapper CONSUMER_GROUP_MAPPER = new ConsumerGroupMapper();
     private static final RowMapper<Long> ID_MAPPER = new IdMapper();
 
-    public ConsumerGroupRepository(DataSource ds) {
+    public ConsumerGroupRepository(final DataSource ds) {
         super(ds);
     }
 
-    public long create(String name) {
+    public long create(final String name) {
         return queryOne("{CALL sp_consumer_groups__create(?)}", ID_MAPPER, name).orElseThrow();
     }
 
-    public void delete(String name) {
+    public void delete(final String name) {
         update("{CALL sp_consumer_groups__delete(?)}", name);
     }
 
-    public long subscribe(String consumerGroup, String path, String topic) {
+    public long subscribe(final String consumerGroup, final String path, final String topic) {
         return queryOne("{CALL sp_consumer_groups__subscribe(?,?,?)}", ID_MAPPER, consumerGroup, path, topic).orElseThrow();
     }
 
-    public void unsubscribe(String consumerGroup, String path, String topic) {
+    public void unsubscribe(final String consumerGroup, final String path, final String topic) {
         update("{CALL sp_consumer_groups__unsubscribe(?,?,?)}", consumerGroup, path, topic);
     }
 
-    public Optional<ConsumerGroup> find(String name) {
+    public Optional<ConsumerGroup> find(final String name) {
         return queryOne("SELECT * FROM consumer_groups WHERE name = ?", CONSUMER_GROUP_MAPPER, name);
     }
 
-    public List<ConsumerGroup> findAll(int limit, int offset) {
+    public List<ConsumerGroup> findAll(final int limit, final int offset) {
         return query("SELECT * FROM consumer_groups ORDER BY id LIMIT ? OFFSET ?", CONSUMER_GROUP_MAPPER, limit, offset);
     }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/ConsumerRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/ConsumerRepository.java
@@ -17,19 +17,19 @@ public final class ConsumerRepository extends BaseRepository {
     private static final CheckInResultMapper CHECK_IN_RESULT_MAPPER = new CheckInResultMapper();
     private static final CursorMapper CURSOR_MAPPER = new CursorMapper();
 
-    public ConsumerRepository(DataSource ds) {
+    public ConsumerRepository(final DataSource ds) {
         super(ds);
     }
 
-    public Optional<Consumer> find(String id) {
+    public Optional<Consumer> find(final String id) {
         return queryOne("SELECT * FROM consumers WHERE id = ?", CONSUMER_MAPPER, id);
     }
 
-    public List<Consumer> findAll(int limit, int offset) {
+    public List<Consumer> findAll(final int limit, final int offset) {
         return query("SELECT * FROM consumers ORDER BY id LIMIT ? OFFSET ?", CONSUMER_MAPPER, limit, offset);
     }
 
-    public CheckInResult checkIn(String consumerId, long consumerGroupId, double weight) {
+    public CheckInResult checkIn(final String consumerId, final long consumerGroupId, final double weight) {
         try (final var connection = ds.getConnection();
              final var statement = connection.prepareCall("{CALL sp_consumers__check_in(?, ?, ?)}")) {
             statement.setString(1, consumerId);
@@ -64,11 +64,11 @@ public final class ConsumerRepository extends BaseRepository {
         }
     }
 
-    public void delete(String id) {
+    public void delete(final String id) {
         update("{CALL sp_consumers__delete(?)}", id);
     }
 
-    public void shutdown(String id) {
+    public void shutdown(final String id) {
         update("{CALL sp_consumers__shutdown(?)}", id);
     }
 

--- a/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
@@ -11,19 +11,19 @@ public final class CursorRepository extends BaseRepository {
 
     private static final CursorMapper CURSOR_MAPPER = new CursorMapper();
 
-    public CursorRepository(DataSource ds) {
+    public CursorRepository(final DataSource ds) {
         super(ds);
     }
 
-    public void commit(long id, long position) {
+    public void commit(final long id, final long position) {
         update("{CALL sp_cursors__commit(?,?)}", id, position);
     }
 
-    public Optional<Cursor> find(long id) {
+    public Optional<Cursor> find(final long id) {
         return queryOne("SELECT * FROM cursors WHERE id = ?", CURSOR_MAPPER, id);
     }
 
-    public Optional<Cursor> find(long consumerGroupId, long partitionId) {
+    public Optional<Cursor> find(final long consumerGroupId, final long partitionId) {
         return queryOne("""
                 SELECT c.* FROM cursors c
                 JOIN subscriptions st ON c.subscription_id = st.id
@@ -31,7 +31,7 @@ public final class CursorRepository extends BaseRepository {
                 """, CURSOR_MAPPER, consumerGroupId, partitionId);
     }
 
-    public List<Cursor> findAll(long consumerGroupId) {
+    public List<Cursor> findAll(final long consumerGroupId) {
         return query("""
                 SELECT c.* FROM cursors c
                 JOIN subscriptions st ON c.subscription_id = st.id
@@ -40,12 +40,12 @@ public final class CursorRepository extends BaseRepository {
     }
 
 
-    public List<Cursor> findLeasable(int limit, int offset) {
+    public List<Cursor> findLeasable(final int limit, final int offset) {
         return query("SELECT * FROM unleased_cursors_view ORDER BY id LIMIT ? OFFSET ?",
                 CURSOR_MAPPER, limit, offset);
     }
 
-    public List<Cursor> findLeasable(long consumerGroupId, int limit, int offset) {
+    public List<Cursor> findLeasable(final long consumerGroupId, final int limit, final int offset) {
         return query("SELECT * FROM unleased_cursors_view WHERE consumer_group_id = ? ORDER BY id LIMIT ? OFFSET ?",
                 CURSOR_MAPPER, consumerGroupId, limit, offset);
     }

--- a/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
@@ -4,15 +4,15 @@ import javax.sql.DataSource;
 
 public final class EventRepository extends BaseRepository {
 
-    public EventRepository(DataSource ds) {
+    public EventRepository(final DataSource ds) {
         super(ds);
     }
 
-    public void publish(String path, String topic, String key, String data) {
+    public void publish(final String path, final String topic, final String key, final String data) {
         update("{CALL sp_events__publish(?,?,?,?)}", path, topic, key, data);
     }
 
-    public void publish(long partitionId, String data) {
+    public void publish(final long partitionId, final String data) {
         update("{CALL sp_events__publish_advanced(?,?)}", partitionId, data);
     }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/HeartbeatPolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/HeartbeatPolicyRepository.java
@@ -1,0 +1,27 @@
+package boxy.core.repository;
+
+import boxy.core.domain.HeartbeatPolicy;
+import boxy.core.mapper.HeartbeatPolicyMapper;
+
+import javax.sql.DataSource;
+
+public final class HeartbeatPolicyRepository extends BaseRepository {
+
+    private static final HeartbeatPolicyMapper MAPPER = new HeartbeatPolicyMapper();
+
+    public HeartbeatPolicyRepository(DataSource ds) {
+        super(ds);
+    }
+
+    public HeartbeatPolicy get() {
+        return queryOne("SELECT * FROM heartbeat_policies WHERE id = 1", MAPPER).orElseThrow();
+    }
+
+    public void update(HeartbeatPolicy policy) {
+        update("{CALL sp_heartbeat_policies__update(?,?,?,?)}",
+                policy.heartbeatDeadlineMultiplier(),
+                policy.heartbeatIntervalBaseline(),
+                policy.heartbeatIntervalLimit(),
+                policy.heartbeatTargetQps());
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/repository/HeartbeatPolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/HeartbeatPolicyRepository.java
@@ -9,15 +9,15 @@ public final class HeartbeatPolicyRepository extends BaseRepository {
 
     private static final HeartbeatPolicyMapper MAPPER = new HeartbeatPolicyMapper();
 
-    public HeartbeatPolicyRepository(DataSource ds) {
+    public HeartbeatPolicyRepository(final DataSource ds) {
         super(ds);
     }
 
     public HeartbeatPolicy get() {
-        return queryOne("SELECT * FROM heartbeat_policies WHERE id = 1", MAPPER).orElseThrow();
+        return queryOne("SELECT * FROM heartbeat_policies LIMIT 1", MAPPER).orElseThrow();
     }
 
-    public void update(HeartbeatPolicy policy) {
+    public void update(final HeartbeatPolicy policy) {
         update("{CALL sp_heartbeat_policies__update(?,?,?,?)}",
                 policy.heartbeatDeadlineMultiplier(),
                 policy.heartbeatIntervalBaseline(),

--- a/boxy-core/src/main/java/boxy/core/repository/LeasePolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/LeasePolicyRepository.java
@@ -9,7 +9,7 @@ public final class LeasePolicyRepository extends BaseRepository {
 
     private static final LeasePolicyMapper MAPPER = new LeasePolicyMapper();
 
-    public LeasePolicyRepository(DataSource ds) {
+    public LeasePolicyRepository(final DataSource ds) {
         super(ds);
     }
 
@@ -17,7 +17,7 @@ public final class LeasePolicyRepository extends BaseRepository {
         return queryOne("SELECT * FROM lease_policies WHERE id = 1", MAPPER).orElseThrow();
     }
 
-    public void update(LeasePolicy policy) {
+    public void update(final LeasePolicy policy) {
         update("{CALL sp_lease_policies__update(?,?)}",
                 policy.activeConsumersLimit(),
                 policy.leaseReleasePeriod());

--- a/boxy-core/src/main/java/boxy/core/repository/LeasePolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/LeasePolicyRepository.java
@@ -1,0 +1,25 @@
+package boxy.core.repository;
+
+import boxy.core.domain.LeasePolicy;
+import boxy.core.mapper.LeasePolicyMapper;
+
+import javax.sql.DataSource;
+
+public final class LeasePolicyRepository extends BaseRepository {
+
+    private static final LeasePolicyMapper MAPPER = new LeasePolicyMapper();
+
+    public LeasePolicyRepository(DataSource ds) {
+        super(ds);
+    }
+
+    public LeasePolicy get() {
+        return queryOne("SELECT * FROM lease_policies WHERE id = 1", MAPPER).orElseThrow();
+    }
+
+    public void update(LeasePolicy policy) {
+        update("{CALL sp_lease_policies__update(?,?)}",
+                policy.activeConsumersLimit(),
+                policy.leaseReleasePeriod());
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/repository/LeaseRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/LeaseRepository.java
@@ -11,15 +11,15 @@ public final class LeaseRepository extends BaseRepository {
 
     private static final LeaseMapper LEASE_MAPPER = new LeaseMapper();
 
-    public LeaseRepository(DataSource ds) {
+    public LeaseRepository(final DataSource ds) {
         super(ds);
     }
 
-    public Optional<Lease> find(long cursorId) {
+    public Optional<Lease> find(final long cursorId) {
         return queryOne("SELECT * FROM leases WHERE cursor_id = ?", LEASE_MAPPER, cursorId);
     }
 
-    public void release(long cursorId, String consumerId) {
+    public void release(final long cursorId, final String consumerId) {
         update("{CALL sp_leases__release(?,?)}", cursorId, consumerId);
     }
 

--- a/boxy-core/src/main/java/boxy/core/repository/MetricsPolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/MetricsPolicyRepository.java
@@ -1,0 +1,24 @@
+package boxy.core.repository;
+
+import boxy.core.domain.MetricsPolicy;
+import boxy.core.mapper.MetricsPolicyMapper;
+
+import javax.sql.DataSource;
+
+public final class MetricsPolicyRepository extends BaseRepository {
+
+    private static final MetricsPolicyMapper MAPPER = new MetricsPolicyMapper();
+
+    public MetricsPolicyRepository(DataSource ds) {
+        super(ds);
+    }
+
+    public MetricsPolicy get() {
+        return queryOne("SELECT * FROM metrics_policies WHERE id = 1", MAPPER).orElseThrow();
+    }
+
+    public void update(MetricsPolicy policy) {
+        update("{CALL sp_metrics_policies__update(?)}",
+                policy.metricsRefreshInterval());
+    }
+}

--- a/boxy-core/src/main/java/boxy/core/repository/MetricsPolicyRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/MetricsPolicyRepository.java
@@ -9,7 +9,7 @@ public final class MetricsPolicyRepository extends BaseRepository {
 
     private static final MetricsPolicyMapper MAPPER = new MetricsPolicyMapper();
 
-    public MetricsPolicyRepository(DataSource ds) {
+    public MetricsPolicyRepository(final DataSource ds) {
         super(ds);
     }
 
@@ -17,8 +17,7 @@ public final class MetricsPolicyRepository extends BaseRepository {
         return queryOne("SELECT * FROM metrics_policies WHERE id = 1", MAPPER).orElseThrow();
     }
 
-    public void update(MetricsPolicy policy) {
-        update("{CALL sp_metrics_policies__update(?)}",
-                policy.metricsRefreshInterval());
+    public void update(final MetricsPolicy policy) {
+        update("{CALL sp_metrics_policies__update(?)}", policy.metricsRefreshInterval());
     }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/NamespaceRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/NamespaceRepository.java
@@ -13,7 +13,7 @@ public final class NamespaceRepository extends BaseRepository {
     private static final NamespaceMapper NAMESPACE_MAPPER = new NamespaceMapper();
     private static final RowMapper<Long> ID_MAPPER = new IdMapper();
 
-    public NamespaceRepository(DataSource ds) {
+    public NamespaceRepository(final DataSource ds) {
         super(ds);
     }
 
@@ -21,19 +21,19 @@ public final class NamespaceRepository extends BaseRepository {
         return queryOne("{CALL sp_namespaces__create(?)}", ID_MAPPER, path).orElseThrow();
     }
 
-    public void delete(String path) {
+    public void delete(final String path) {
         update("{CALL sp_namespaces__delete(?)}", path);
     }
 
-    public void rename(String path, String newName) {
+    public void rename(final String path, final String newName) {
         update("{CALL sp_namespaces__rename(?, ?)}", path, newName);
     }
 
-    public void move(String path, String newParentPath) {
+    public void move(final String path, final String newParentPath) {
         update("{CALL sp_namespaces__move(?, ?)}", path, newParentPath);
     }
 
-    public Optional<Namespace> find(String path) {
+    public Optional<Namespace> find(final String path) {
         return queryOne("SELECT * FROM namespaces WHERE path_hash = UNHEX(MD5(?)) AND path = ?", NAMESPACE_MAPPER, path, path);
     }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/PartitionRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/PartitionRepository.java
@@ -10,23 +10,21 @@ public final class PartitionRepository extends BaseRepository {
 
     private static final PartitionMapper PARTITION_MAPPER = new PartitionMapper();
 
-    public PartitionRepository(DataSource ds) {
+    public PartitionRepository(final DataSource ds) {
         super(ds);
     }
 
-    public Optional<Partition> find(String path, String topic, int partitionNumber) {
+    public Optional<Partition> find(final String path, final String topic, final int partitionNumber) {
         return queryOne("""
-                        SELECT p.*
-                          FROM partitions p
-                          JOIN topics t ON p.topic_id = t.id
-                          JOIN namespaces n ON n.id = t.namespace_id
-                         WHERE n.path_hash       = UNHEX(MD5(?))
-                           AND n.path            = ?
-                           AND t.name            = ?
-                           AND p.partition_number = ?
-                        """,
-                PARTITION_MAPPER,
-                path, path, topic, partitionNumber);
+                SELECT p.*
+                  FROM partitions p
+                  JOIN topics t ON p.topic_id = t.id
+                  JOIN namespaces n ON n.id = t.namespace_id
+                 WHERE n.path_hash       = UNHEX(MD5(?))
+                   AND n.path            = ?
+                   AND t.name            = ?
+                   AND p.partition_number = ?
+                """, PARTITION_MAPPER, path, path, topic, partitionNumber);
     }
 
 }

--- a/boxy-core/src/main/java/boxy/core/repository/SubscriptionRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/SubscriptionRepository.java
@@ -15,7 +15,7 @@ public final class SubscriptionRepository extends BaseRepository {
         super(ds);
     }
 
-    public Optional<Subscription> find(String consumerGroup, String path, String topic) {
+    public Optional<Subscription> find(final String consumerGroup, final String path, final String topic) {
         return queryOne("""
                 SELECT st.* FROM subscriptions st
                     JOIN consumer_groups s ON st.consumer_group_id = s.id
@@ -29,9 +29,8 @@ public final class SubscriptionRepository extends BaseRepository {
     }
 
 
-    public List<Subscription> findAll(int limit, int offset) {
-        return query("SELECT * FROM subscriptions ORDER BY id LIMIT ? OFFSET ?",
-                SUBSCRIPTION_MAPPER, limit, offset);
+    public List<Subscription> findAll(final int limit, final int offset) {
+        return query("SELECT * FROM subscriptions ORDER BY id LIMIT ? OFFSET ?", SUBSCRIPTION_MAPPER, limit, offset);
     }
 
 }

--- a/boxy-core/src/main/java/boxy/core/repository/TopicRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/TopicRepository.java
@@ -13,15 +13,15 @@ public final class TopicRepository extends BaseRepository {
     private static final TopicMapper TOPIC_MAPPER = new TopicMapper();
     private static final RowMapper<Long> ID_MAPPER = new IdMapper();
 
-    public TopicRepository(DataSource ds) {
+    public TopicRepository(final DataSource ds) {
         super(ds);
     }
 
-    public long create(String path, String name, int partitions) {
+    public long create(final String path, final String name, final int partitions) {
         return queryOne("{CALL sp_topics__create(?,?,?)}", ID_MAPPER, path, name, partitions).orElseThrow();
     }
 
-    public Optional<Topic> find(String path, String name) {
+    public Optional<Topic> find(final String path, final String name) {
         return queryOne("""
                 SELECT t.*
                   FROM topics t
@@ -32,7 +32,7 @@ public final class TopicRepository extends BaseRepository {
                 """, TOPIC_MAPPER, path, path, name);
     }
 
-    public void delete(String path, String name) {
+    public void delete(final String path, final String name) {
         update("{CALL sp_topics__delete(?,?)}", path, name);
     }
 

--- a/boxy-core/src/test/java/boxy/core/it/BaseIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/BaseIT.java
@@ -14,10 +14,14 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 import javax.sql.DataSource;
 
 public abstract class BaseIT {
+
+    private static final Set<String> PROTECTED_TABLES = Set.of("heartbeat_policies", "metrics_policies", "lease_policies");
 
     @Container
     private static final MySQLContainer<?> MYSQL =
@@ -42,7 +46,6 @@ public abstract class BaseIT {
 
     @BeforeAll
     static void setupDB() throws SQLException, LiquibaseException {
-        // Configure JDBC connections settings
         System.setProperty("DB_HOST", MYSQL.getHost());
         System.setProperty("DB_PORT", MYSQL.getMappedPort(MySQLContainer.MYSQL_PORT).toString());
         System.setProperty("DB_NAME", MYSQL.getDatabaseName());
@@ -77,12 +80,28 @@ public abstract class BaseIT {
         }
         DataSourceProvider.close();
     }
+
     void teardownPGSQL(final java.sql.Connection conn) throws SQLException {
-        try (var stmt = conn.createStatement()) {
-            final var rs = stmt.executeQuery("SELECT string_agg(quote_ident(tablename), ', ') FROM pg_tables WHERE schemaname = 'public'");
-            rs.next();
-            final var tables = rs.getString(1);
-            stmt.execute("TRUNCATE TABLE " + tables + " RESTART IDENTITY CASCADE;");
+        try (final var stmt = conn.createStatement();
+             final var rs = stmt.executeQuery("SELECT quote_ident(tablename) FROM pg_tables WHERE schemaname = 'public'")) {
+
+            final var tables = new ArrayList<String>();
+            while (rs.next()) {
+                final var table = rs.getString(1);
+                if (!PROTECTED_TABLES.contains(table.toLowerCase())) {
+                    tables.add(rs.getString(1));
+                }
+            }
+            for (final var table : tables) {
+                stmt.addBatch("ALTER TABLE %s DISABLE TRIGGER ALL;".formatted(table));
+            }
+            for (final var table : tables) {
+                stmt.addBatch("TRUNCATE TABLE %s RESTART IDENTITY;".formatted(table));
+            }
+            for (final var table : tables) {
+                stmt.addBatch("ALTER TABLE %s ENABLE TRIGGER ALL;".formatted(table));
+            }
+            stmt.executeBatch();
         }
     }
 
@@ -91,7 +110,10 @@ public abstract class BaseIT {
             stmt.execute("SET FOREIGN_KEY_CHECKS = 0;");
             try (var rs = stmt.executeQuery("SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND table_schema = DATABASE()")) {
                 while (rs.next()) {
-                    stmt.addBatch("TRUNCATE TABLE `" + rs.getString(1) + "`");
+                    final var table = rs.getString(1);
+                    if (!PROTECTED_TABLES.contains(table.toLowerCase())) {
+                        stmt.addBatch("TRUNCATE TABLE `%s`".formatted(table));
+                    }
                 }
                 stmt.executeBatch();
             }

--- a/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
@@ -32,12 +32,8 @@ public class ConsumerGroupIT extends BaseIT {
         System.out.println("[DEBUG_LOG] Consumer Group fields:");
         System.out.println("[DEBUG_LOG]   ID: " + consumerGroup.id());
         System.out.println("[DEBUG_LOG]   Name: " + consumerGroup.name());
-        System.out.println("[DEBUG_LOG]   Heartbeat Interval Default: " + consumerGroup.heartbeatIntervalBaseline());
-        System.out.println("[DEBUG_LOG]   Heartbeat Deadline Multiplier: " + consumerGroup.heartbeatDeadlineMultiplier());
-        System.out.println("[DEBUG_LOG]   Lease Release Period: " + consumerGroup.leaseReleasePeriod());
-        System.out.println("[DEBUG_LOG]   Heartbeat QPS Target: " + consumerGroup.heartbeatTargetQPS());
-        System.out.println("[DEBUG_LOG]   Heartbeat Interval Limit: " + consumerGroup.heartbeatIntervalLimit());
         System.out.println("[DEBUG_LOG]   Active Consumers Count: " + consumerGroup.activeConsumers());
+        System.out.println("[DEBUG_LOG]   Heartbeat Interval: " + consumerGroup.heartbeatInterval());
         System.out.println("[DEBUG_LOG]   Total Weight: " + consumerGroup.activeConsumersWeight());
         System.out.println("[DEBUG_LOG]   Active Partitions Count: " + consumerGroup.activePartitions());
         System.out.println("[DEBUG_LOG]   Last Modified At: " + consumerGroup.lastModifiedAt());

--- a/boxy-core/src/test/java/boxy/core/it/PolicyRepositoryIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/PolicyRepositoryIT.java
@@ -29,7 +29,7 @@ public class PolicyRepositoryIT extends BaseIT {
     @Test
     void heartbeatPolicy_updateAndGet() {
         HeartbeatPolicy current = heartbeatPolicyRepository.get();
-        HeartbeatPolicy updated = new HeartbeatPolicy(current.id(), 2.0, 4.0, 5.0, 8.0);
+        HeartbeatPolicy updated = new HeartbeatPolicy(2.0, 4.0, 5.0, 8.0);
         heartbeatPolicyRepository.update(updated);
         assertThat(heartbeatPolicyRepository.get()).isEqualTo(updated);
     }
@@ -37,7 +37,7 @@ public class PolicyRepositoryIT extends BaseIT {
     @Test
     void leasePolicy_updateAndGet() {
         LeasePolicy current = leasePolicyRepository.get();
-        LeasePolicy updated = new LeasePolicy(current.id(), current.activeConsumersLimit() + 1, current.leaseReleasePeriod() + 1);
+        LeasePolicy updated = new LeasePolicy(current.activeConsumersLimit() + 1, current.leaseReleasePeriod() + 1);
         leasePolicyRepository.update(updated);
         assertThat(leasePolicyRepository.get()).isEqualTo(updated);
     }
@@ -45,7 +45,7 @@ public class PolicyRepositoryIT extends BaseIT {
     @Test
     void metricsPolicy_updateAndGet() {
         MetricsPolicy current = metricsPolicyRepository.get();
-        MetricsPolicy updated = new MetricsPolicy(current.id(), current.metricsRefreshInterval() + 1);
+        MetricsPolicy updated = new MetricsPolicy(current.metricsRefreshInterval() + 1);
         metricsPolicyRepository.update(updated);
         assertThat(metricsPolicyRepository.get()).isEqualTo(updated);
     }

--- a/boxy-core/src/test/java/boxy/core/it/PolicyRepositoryIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/PolicyRepositoryIT.java
@@ -1,0 +1,52 @@
+package boxy.core.it;
+
+import boxy.core.domain.HeartbeatPolicy;
+import boxy.core.domain.LeasePolicy;
+import boxy.core.domain.MetricsPolicy;
+import boxy.core.repository.HeartbeatPolicyRepository;
+import boxy.core.repository.LeasePolicyRepository;
+import boxy.core.repository.MetricsPolicyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+public class PolicyRepositoryIT extends BaseIT {
+
+    private HeartbeatPolicyRepository heartbeatPolicyRepository;
+    private LeasePolicyRepository leasePolicyRepository;
+    private MetricsPolicyRepository metricsPolicyRepository;
+
+    @BeforeEach
+    void setup() {
+        heartbeatPolicyRepository = new HeartbeatPolicyRepository(dataSource);
+        leasePolicyRepository = new LeasePolicyRepository(dataSource);
+        metricsPolicyRepository = new MetricsPolicyRepository(dataSource);
+    }
+
+    @Test
+    void heartbeatPolicy_updateAndGet() {
+        HeartbeatPolicy current = heartbeatPolicyRepository.get();
+        HeartbeatPolicy updated = new HeartbeatPolicy(current.id(), 2.0, 4.0, 5.0, 8.0);
+        heartbeatPolicyRepository.update(updated);
+        assertThat(heartbeatPolicyRepository.get()).isEqualTo(updated);
+    }
+
+    @Test
+    void leasePolicy_updateAndGet() {
+        LeasePolicy current = leasePolicyRepository.get();
+        LeasePolicy updated = new LeasePolicy(current.id(), current.activeConsumersLimit() + 1, current.leaseReleasePeriod() + 1);
+        leasePolicyRepository.update(updated);
+        assertThat(leasePolicyRepository.get()).isEqualTo(updated);
+    }
+
+    @Test
+    void metricsPolicy_updateAndGet() {
+        MetricsPolicy current = metricsPolicyRepository.get();
+        MetricsPolicy updated = new MetricsPolicy(current.id(), current.metricsRefreshInterval() + 1);
+        metricsPolicyRepository.update(updated);
+        assertThat(metricsPolicyRepository.get()).isEqualTo(updated);
+    }
+}

--- a/boxy-core/src/test/java/boxy/core/it/TestData.java
+++ b/boxy-core/src/test/java/boxy/core/it/TestData.java
@@ -69,6 +69,7 @@ public record TestData(Topic topic,
 
         final var cursor = cursorRepository.findAll(consumerGroups.getFirst().id()).getFirst();
 
+        System.out.println(new HeartbeatPolicyRepository(ds).get());
         consumerRepository.checkIn(PARTY_1, consumerGroups.get(0).id(), 1);
         consumerRepository.checkIn(PARTY_2, consumerGroups.get(1).id(), 1);
         final var consumer1 = consumerRepository.find(PARTY_1).orElseThrow();

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
@@ -26,6 +26,20 @@
                  splitStatements="false"
                  stripComments="false"/>
 
+        <!-- SP: POLICIES -->
+        <sqlFile path="sp/sp_heartbeat_policies__update.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="false"
+                 stripComments="false"/>
+        <sqlFile path="sp/sp_lease_policies__update.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="false"
+                 stripComments="false"/>
+        <sqlFile path="sp/sp_metrics_policies__update.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="false"
+                 stripComments="false"/>
+
         <!-- SP: CONSUMERS -->
         <sqlFile path="sp/sp_consumers__delete.sql"
                  relativeToChangelogFile="true"

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -56,19 +56,46 @@ CREATE TABLE partitions (
     COLLATE=utf8mb4_bin
     COMMENT='Tracks partitions for each topic';
 
+CREATE TABLE heartbeat_policies (
+    id                           TINYINT NOT NULL PRIMARY KEY CHECK (id = 1),
+    heartbeat_deadline_multiplier DOUBLE NOT NULL DEFAULT 5.0,
+    heartbeat_interval_baseline   DOUBLE NOT NULL DEFAULT 3.0,
+    heartbeat_interval_limit      DOUBLE NOT NULL DEFAULT 60.0,
+    heartbeat_target_qps          DOUBLE NOT NULL DEFAULT 10.0
+) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4
+    COLLATE=utf8mb4_bin
+    COMMENT='Stores cluster-wide heartbeat configuration';
+
+INSERT INTO heartbeat_policies (id) VALUES (1);
+
+CREATE TABLE lease_policies (
+    id                      TINYINT NOT NULL PRIMARY KEY CHECK (id = 1),
+    active_consumers_limit  INT     NOT NULL DEFAULT 16,
+    lease_release_period    INT     NOT NULL DEFAULT 10
+) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4
+    COLLATE=utf8mb4_bin
+    COMMENT='Stores cluster-wide lease configuration';
+
+INSERT INTO lease_policies (id) VALUES (1);
+
+CREATE TABLE metrics_policies (
+    id                      TINYINT NOT NULL PRIMARY KEY CHECK (id = 1),
+    metrics_refresh_interval INT    NOT NULL DEFAULT 3
+) ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4
+    COLLATE=utf8mb4_bin
+    COMMENT='Stores cluster-wide metrics configuration';
+
+INSERT INTO metrics_policies (id) VALUES (1);
+
 CREATE TABLE consumer_groups (
     id                              BIGINT AUTO_INCREMENT PRIMARY KEY,
     name                            VARCHAR(500) NOT NULL,
-    heartbeat_deadline_multiplier   DOUBLE NOT NULL DEFAULT 5.0,
-    heartbeat_interval_baseline     DOUBLE NOT NULL DEFAULT 3.0,
     heartbeat_interval              DOUBLE NOT NULL DEFAULT 15.0,
-    heartbeat_interval_limit        DOUBLE NOT NULL DEFAULT 60.00,
-    heartbeat_target_qps            DOUBLE NOT NULL DEFAULT 10.0,
-    metrics_refresh_interval        INT NOT NULL DEFAULT 3,
-    lease_release_period            INT NOT NULL DEFAULT 10,
     active_partitions               INT NOT NULL DEFAULT 0,
     active_consumers                INT NOT NULL DEFAULT 0,
-    active_consumers_limit          INT NOT NULL DEFAULT 16,
     active_consumers_weight         DOUBLE NOT NULL DEFAULT 0,
     last_modified_at                DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     CONSTRAINT u_consumer_groups UNIQUE (name)

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumer_groups__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumer_groups__refresh_metrics.sql
@@ -35,8 +35,7 @@ BEGIN
       INTO v_heartbeat_target_qps,
            v_heartbeat_interval_baseline,
            v_heartbeat_interval_limit
-      FROM consumer_groups
-     WHERE id = p_consumer_group_id;
+      FROM heartbeat_policies;
 
 
     -- CALCULATE HEARTBEAT FROM TARGET QPS

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumer_groups__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumer_groups__refresh_metrics.sql
@@ -28,7 +28,7 @@ BEGIN
      WHERE c.position < p.high_watermark
        AND st.consumer_group_id = p_consumer_group_id;
 
-    -- METRICS
+    -- POLICY
     SELECT heartbeat_target_qps,
            heartbeat_interval_baseline,
            heartbeat_interval_limit
@@ -36,6 +36,11 @@ BEGIN
            v_heartbeat_interval_baseline,
            v_heartbeat_interval_limit
       FROM heartbeat_policies;
+
+    -- VERIFY POLICY IS FOUND
+    IF v_heartbeat_target_qps IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'No heartbeat policy found.';
+    END IF;
 
 
     -- CALCULATE HEARTBEAT FROM TARGET QPS

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__heartbeat.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__heartbeat.sql
@@ -24,11 +24,13 @@ BEGIN
         SELECT p_consumer_id,
                p_consumer_group_id,
                p_weight,
-               heartbeat_interval_baseline,
+               hp.heartbeat_interval_baseline,
                v_timestamp + INTERVAL 1 SECOND
-          FROM consumer_groups
-         WHERE active_consumers < active_consumers_limit
-           AND id = p_consumer_group_id;
+          FROM consumer_groups cg
+          CROSS JOIN heartbeat_policies hp
+          CROSS JOIN lease_policies lp
+         WHERE cg.active_consumers < lp.active_consumers_limit
+           AND cg.id = p_consumer_group_id;
         SET p_status = IF(ROW_COUNT() > 0, 'ACCEPTED', 'REJECTED');
     END IF;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
@@ -5,12 +5,13 @@ BEGIN
     DECLARE v_heartbeat_interval DOUBLE;
 
     -- GET METRICS
-    SELECT  heartbeat_deadline_multiplier,
-            heartbeat_interval
-      INTO  v_heartbeat_deadline_multiplier,
-            v_heartbeat_interval
-      FROM consumer_groups
-     WHERE id = p_consumer_group_id;
+    SELECT hp.heartbeat_deadline_multiplier,
+           cg.heartbeat_interval
+      INTO v_heartbeat_deadline_multiplier,
+           v_heartbeat_interval
+      FROM consumer_groups cg
+      CROSS JOIN heartbeat_policies hp
+     WHERE cg.id = p_consumer_group_id;
 
     -- CONSUMER UPDATE
     SET v_heartbeat_timeout_period = GREATEST(1, CEILING(v_heartbeat_interval * v_heartbeat_deadline_multiplier));

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_heartbeat_policies__update.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_heartbeat_policies__update.sql
@@ -1,0 +1,13 @@
+CREATE PROCEDURE sp_heartbeat_policies__update(
+    IN p_heartbeat_deadline_multiplier DOUBLE,
+    IN p_heartbeat_interval_baseline DOUBLE,
+    IN p_heartbeat_interval_limit DOUBLE,
+    IN p_heartbeat_target_qps DOUBLE)
+BEGIN
+    UPDATE heartbeat_policies
+       SET heartbeat_deadline_multiplier = p_heartbeat_deadline_multiplier,
+           heartbeat_interval_baseline = p_heartbeat_interval_baseline,
+           heartbeat_interval_limit = p_heartbeat_interval_limit,
+           heartbeat_target_qps = p_heartbeat_target_qps
+     WHERE id = 1;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_lease_policies__update.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_lease_policies__update.sql
@@ -1,0 +1,9 @@
+CREATE PROCEDURE sp_lease_policies__update(
+    IN p_active_consumers_limit INT,
+    IN p_lease_release_period INT)
+BEGIN
+    UPDATE lease_policies
+       SET active_consumers_limit = p_active_consumers_limit,
+           lease_release_period = p_lease_release_period
+     WHERE id = 1;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_leases__release.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_leases__release.sql
@@ -6,11 +6,12 @@ BEGIN
     DECLARE v_release_period INT;
 
     -- GET THE RELEASE PERIOD
-    SELECT consumer_groups.lease_release_period
+    SELECT lp.lease_release_period
       INTO v_release_period
-      FROM consumers
-      JOIN consumer_groups ON consumer_groups.id = consumers.consumer_group_id
-     WHERE consumers.id = p_consumer_id;
+      FROM consumers c
+      JOIN consumer_groups cg ON cg.id = c.consumer_group_id
+      CROSS JOIN lease_policies lp
+     WHERE c.id = p_consumer_id;
 
     -- RELEASE THE LEASE
     UPDATE leases 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_leases__release_excess.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_leases__release_excess.sql
@@ -8,8 +8,7 @@ BEGIN
     -- GET THE RELEASE PERIOD
     SELECT lease_release_period
       INTO v_release_period
-      FROM consumer_groups
-     WHERE id = p_consumer_group_id;
+      FROM lease_policies;
 
     -- Release leases when we have too many
     -- Among the leases held, identify:

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_metrics_policies__update.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_metrics_policies__update.sql
@@ -1,0 +1,7 @@
+CREATE PROCEDURE sp_metrics_policies__update(
+    IN p_metrics_refresh_interval INT)
+BEGIN
+    UPDATE metrics_policies
+       SET metrics_refresh_interval = p_metrics_refresh_interval
+     WHERE id = 1;
+END;


### PR DESCRIPTION
## Summary
- move heartbeat, lease, and metrics settings from `consumer_groups` to new singleton policy tables
- refactor stored procedures to read cluster policy tables and add updates via dedicated policy repositories

## Testing
- `mvn -q test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_68911c7b9484832fa5fff643452668a3