### PR TITLE
Move consumer group metrics to subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,22 +90,23 @@ erDiagram
 - **topics**: belong to namespaces and declare a partition count.
 - **partitions**: per-topic shards that track a `high_watermark`.
 - **events**: append-only records stored per partition.
-- **subscriptions**: links consumer groups to the topics they consume.
+- **subscriptions**: links consumer groups to the topics they consume and stores precomputed statistics.
 - **cursors**: tracks the position per subscription and partition.
   Each row is assigned a persistent `random_key` used for evenly
   distributing the start position when acquiring leases.
 - **consumers**: registers each consumer’s `consumer_group_id`, `weight`, and `heartbeat_detected_at`.
 - **leases**: one row per `cursor` when a consumer holds a lease, with `state` indicating whether it's 'ACTIVE' or 'RELEASING'.
-- **consumer_groups**: stores precomputed statistics for each consumer group.
+- **consumer_groups**: defines logical groups of consumers.
 - **heartbeat_policies**, **lease_policies**, **metrics_policies**: singleton tables providing cluster-wide configuration.
 - **topics_cache**: in-memory table for quick topic lookups.
 
-### Consumer Group Statistics
+### Subscription Statistics
 
-The `consumer_groups` table stores precomputed statistics that are updated with each consumer check-in:
+The `subscriptions` table stores precomputed statistics that are updated with each consumer check-in:
 
+- **heartbeat_interval**: Adaptive interval used for consumer heartbeats.
 - **active_partitions**: Count of partitions with new events (high_watermark > position).
-- **active_consumers**: Count of consumers with valid heartbeats. 
+- **active_consumers**: Count of consumers with valid heartbeats.
 - **active_consumers_weight**: Sum of weights of all active consumers in the consumer group.
 - **last_modified_at**: Timestamp of the last statistics update.
 
@@ -264,10 +265,11 @@ Properties
 
 The work-stealing algorithm is implemented in the `sp_consumers__check_in` stored procedure and its sub-procedures. The algorithm works as follows:
 
-1. **Consumer Group Statistics Update**:
-   - The procedure updates precomputed statistics in the `consumer_groups` table:
+1. **Subscription Statistics Update**:
+   - The procedure updates precomputed statistics in the `subscriptions` table:
+     - `heartbeat_interval`: Adaptive interval for consumer heartbeats
      - `active_partitions`: Count of partitions with new events (high_watermark > position)
-     - `active_consumers`: Count of consumers with valid heartbeats    
+     - `active_consumers`: Count of consumers with valid heartbeats
      - `active_consumers_weight`: Sum of weights of all active consumers
    - These statistics are used for fair share calculation and adaptive heartbeat intervals.
 

--- a/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
+++ b/boxy-core/src/main/java/boxy/core/domain/ConsumerGroup.java
@@ -5,9 +5,5 @@ import java.time.Instant;
 public record ConsumerGroup(
         long id,
         String name,
-        double heartbeatInterval,
-        int activePartitions,
-        int activeConsumers,
-        double activeConsumersWeight,
         Instant lastModifiedAt) {
 }

--- a/boxy-core/src/main/java/boxy/core/domain/Subscription.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Subscription.java
@@ -6,5 +6,10 @@ public record Subscription(
         long id,
         long consumerGroupId,
         long topicId,
-        Instant createdAt) {
+        double heartbeatInterval,
+        int activePartitions,
+        int activeConsumers,
+        double activeConsumersWeight,
+        Instant createdAt,
+        Instant lastModifiedAt) {
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerGroupMapper.java
@@ -11,10 +11,6 @@ public class ConsumerGroupMapper implements RowMapper<ConsumerGroup> {
         return new ConsumerGroup(
                 rs.getLong("id"),
                 rs.getString("name"),
-                rs.getDouble("heartbeat_interval"),
-                rs.getInt("active_partitions"),
-                rs.getInt("active_consumers"),
-                rs.getDouble("active_consumers_weight"),
                 rs.getTimestamp("last_modified_at").toInstant());
     }
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/SubscriptionMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/SubscriptionMapper.java
@@ -12,6 +12,11 @@ public class SubscriptionMapper implements RowMapper<Subscription> {
                 rs.getLong("id"),
                 rs.getLong("consumer_group_id"),
                 rs.getLong("topic_id"),
-                rs.getTimestamp("created_at").toInstant());
+                rs.getDouble("heartbeat_interval"),
+                rs.getInt("active_partitions"),
+                rs.getInt("active_consumers"),
+                rs.getDouble("active_consumers_weight"),
+                rs.getTimestamp("created_at").toInstant(),
+                rs.getTimestamp("last_modified_at").toInstant());
     }
 }

--- a/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/ConsumerGroupIT.java
@@ -26,17 +26,7 @@ public class ConsumerGroupIT extends BaseIT {
 
     @Test
     void create_whenCreated_isPresent() {
-        System.out.println("[DEBUG_LOG] Running create_whenCreated_isPresent test");
         final var consumerGroup = consumerGroupRepository.find(CONSUMER_GROUP_A).orElseThrow();
-        System.out.println("[DEBUG_LOG] Found consumer group: " + consumerGroup);
-        System.out.println("[DEBUG_LOG] Consumer Group fields:");
-        System.out.println("[DEBUG_LOG]   ID: " + consumerGroup.id());
-        System.out.println("[DEBUG_LOG]   Name: " + consumerGroup.name());
-        System.out.println("[DEBUG_LOG]   Active Consumers Count: " + consumerGroup.activeConsumers());
-        System.out.println("[DEBUG_LOG]   Heartbeat Interval: " + consumerGroup.heartbeatInterval());
-        System.out.println("[DEBUG_LOG]   Total Weight: " + consumerGroup.activeConsumersWeight());
-        System.out.println("[DEBUG_LOG]   Active Partitions Count: " + consumerGroup.activePartitions());
-        System.out.println("[DEBUG_LOG]   Last Modified At: " + consumerGroup.lastModifiedAt());
         assertThat(consumerGroup).extracting(ConsumerGroup::name).isEqualTo(CONSUMER_GROUP_A);
     }
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
@@ -85,7 +85,7 @@
                  stripComments="false"/>
 
         <!-- SP: CONSUMER GROUPS -->
-        <sqlFile path="sp/sp_consumer_groups__refresh_metrics.sql"
+        <sqlFile path="sp/sp_subscriptions__refresh_metrics.sql"
                  relativeToChangelogFile="true"
                  splitStatements="false"
                  stripComments="false"/>

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -93,10 +93,6 @@ INSERT INTO metrics_policies (id) VALUES (1);
 CREATE TABLE consumer_groups (
     id                              BIGINT AUTO_INCREMENT PRIMARY KEY,
     name                            VARCHAR(500) NOT NULL,
-    heartbeat_interval              DOUBLE NOT NULL DEFAULT 15.0,
-    active_partitions               INT NOT NULL DEFAULT 0,
-    active_consumers                INT NOT NULL DEFAULT 0,
-    active_consumers_weight         DOUBLE NOT NULL DEFAULT 0,
     last_modified_at                DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     CONSTRAINT u_consumer_groups UNIQUE (name)
 ) ENGINE=InnoDB
@@ -108,7 +104,12 @@ CREATE TABLE subscriptions (
     id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     consumer_group_id   BIGINT NOT NULL,
     topic_id            BIGINT NOT NULL,
+    heartbeat_interval          DOUBLE NOT NULL DEFAULT 15.0,
+    active_partitions           INT NOT NULL DEFAULT 0,
+    active_consumers            INT NOT NULL DEFAULT 0,
+    active_consumers_weight     DOUBLE NOT NULL DEFAULT 0,
     created_at          DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    last_modified_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     FOREIGN KEY (consumer_group_id) REFERENCES consumer_groups (id) ON DELETE CASCADE,
     FOREIGN KEY (topic_id) REFERENCES topics (id) ON DELETE CASCADE,
     CONSTRAINT u_subscriptions UNIQUE (consumer_group_id, topic_id),

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__check_in.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__check_in.sql
@@ -15,7 +15,7 @@ BEGIN
     -- HEARTBEAT
     CALL sp_consumers__heartbeat(p_consumer_id, p_consumer_group_id, p_weight, v_status);
     CALL sp_consumers__gc(p_consumer_group_id);
-    CALL sp_consumer_groups__refresh_metrics(p_consumer_group_id);
+    CALL sp_subscriptions__refresh_metrics(p_consumer_group_id);
 
     -- HANDLE CONSUMER ACCEPTANCE
     IF v_status = 'ACCEPTED' THEN
@@ -30,19 +30,13 @@ BEGIN
          WHERE consumer_id = p_consumer_id
            AND state = 'ACTIVE';
 
-       -- IDEAL W/SLACK OF 10%
-        SELECT COUNT(1)
-          INTO v_leases_active
-          FROM consumer_groups
-         WHERE id = p_consumer_group_id;
-
         -- CALCULATE TARGET FOR LEASES
-        SELECT (p_weight / active_consumers_weight * active_partitions),
-               active_partitions
+        SELECT (p_weight / MAX(active_consumers_weight) * SUM(active_partitions)),
+               SUM(active_partitions)
           INTO v_leases_target,
                v_active_partitions
-          FROM consumer_groups
-         WHERE id = p_consumer_group_id;
+          FROM subscriptions
+         WHERE consumer_group_id = p_consumer_group_id;
 
         SET v_leases_min = GREATEST(FLOOR(v_leases_target * 0.9), 0);
         SET v_leases_max = LEAST(CEILING(v_leases_target * 1.1), v_active_partitions);
@@ -50,7 +44,7 @@ BEGIN
         -- RELEASE / ACQUIRE
         IF (v_leases_active > v_leases_max) THEN
             CALL sp_leases__release_excess(p_consumer_id, p_consumer_group_id, v_leases_active - v_leases_max);
-        ELSEIF (v_leases < v_leases_target) THEN
+        ELSEIF (v_leases_active < v_leases_target) THEN
             CALL sp_leases__acquire(p_consumer_id, p_consumer_group_id, v_leases_target - v_leases_active);
         END IF;
     END IF;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__heartbeat.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__heartbeat.sql
@@ -26,11 +26,12 @@ BEGIN
                p_weight,
                hp.heartbeat_interval_baseline,
                v_timestamp + INTERVAL 1 SECOND
-          FROM consumer_groups cg
+          FROM (SELECT COALESCE(MAX(active_consumers),0) AS active_consumers
+                  FROM subscriptions
+                 WHERE consumer_group_id = p_consumer_group_id) cg
           CROSS JOIN heartbeat_policies hp
           CROSS JOIN lease_policies lp
-         WHERE cg.active_consumers < lp.active_consumers_limit
-           AND cg.id = p_consumer_group_id;
+         WHERE cg.active_consumers < lp.active_consumers_limit;
         SET p_status = IF(ROW_COUNT() > 0, 'ACCEPTED', 'REJECTED');
     END IF;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
@@ -6,12 +6,12 @@ BEGIN
 
     -- GET METRICS
     SELECT hp.heartbeat_deadline_multiplier,
-           cg.heartbeat_interval
+           MAX(st.heartbeat_interval)
       INTO v_heartbeat_deadline_multiplier,
            v_heartbeat_interval
-      FROM consumer_groups cg
+      FROM subscriptions st
       CROSS JOIN heartbeat_policies hp
-     WHERE cg.id = p_consumer_group_id;
+     WHERE st.consumer_group_id = p_consumer_group_id;
 
     -- CONSUMER UPDATE
     SET v_heartbeat_timeout_period = GREATEST(1, CEILING(v_heartbeat_interval * v_heartbeat_deadline_multiplier));

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__refresh_metrics.sql
@@ -5,7 +5,7 @@ BEGIN
     DECLARE v_heartbeat_interval DOUBLE;
 
     -- GET METRICS
-    SELECT hp.heartbeat_deadline_multiplier,
+    SELECT MAX(hp.heartbeat_deadline_multiplier),
            MAX(st.heartbeat_interval)
       INTO v_heartbeat_deadline_multiplier,
            v_heartbeat_interval

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_subscriptions__refresh_metrics.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_subscriptions__refresh_metrics.sql
@@ -1,32 +1,19 @@
-CREATE PROCEDURE sp_consumer_groups__refresh_metrics(IN p_consumer_group_id BIGINT)
+CREATE PROCEDURE sp_subscriptions__refresh_metrics(IN p_consumer_group_id BIGINT)
 BEGIN
-    -- Variables for the aggregates
     DECLARE v_timestamp TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3);
     DECLARE v_active_consumers INT DEFAULT 0;
     DECLARE v_active_consumers_weight DOUBLE DEFAULT 0;
-    DECLARE v_active_partitions INT DEFAULT 0;
     DECLARE v_heartbeat_interval DOUBLE;
     DECLARE v_heartbeat_interval_baseline DOUBLE;
     DECLARE v_heartbeat_interval_limit DOUBLE;
     DECLARE v_heartbeat_target_qps DOUBLE;
 
     -- ACTIVE CONSUMERS + TOTAL WEIGHT
-    SELECT
-        COUNT(w.id),
-        COALESCE(SUM(w.weight), 0)
+    SELECT COUNT(w.id), COALESCE(SUM(w.weight), 0)
       INTO v_active_consumers, v_active_consumers_weight
       FROM consumers w
      WHERE w.consumer_group_id = p_consumer_group_id
        AND v_timestamp < w.heartbeat_deadline;
-
-    -- ACTIVE PARTITIONS
-    SELECT COUNT(1)
-      INTO v_active_partitions
-      FROM subscriptions st
-      JOIN cursors c ON st.id = c.subscription_id
-      JOIN partitions p ON c.partition_id = p.id
-     WHERE c.position < p.high_watermark
-       AND st.consumer_group_id = p_consumer_group_id;
 
     -- POLICY
     SELECT heartbeat_target_qps,
@@ -37,23 +24,25 @@ BEGIN
            v_heartbeat_interval_limit
       FROM heartbeat_policies;
 
-    -- VERIFY POLICY IS FOUND
     IF v_heartbeat_target_qps IS NULL THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'No heartbeat policy found.';
     END IF;
 
-
-    -- CALCULATE HEARTBEAT FROM TARGET QPS
     SET v_heartbeat_interval = v_heartbeat_interval_baseline;
-    SET v_heartbeat_interval = GREATEST(v_heartbeat_interval, v_active_consumers /  NULLIF(v_heartbeat_target_qps, 0));
+    SET v_heartbeat_interval = GREATEST(v_heartbeat_interval, v_active_consumers / NULLIF(v_heartbeat_target_qps, 0));
     SET v_heartbeat_interval = LEAST(v_heartbeat_interval, v_heartbeat_interval_limit);
 
-    -- UPDATE
-    UPDATE consumer_groups
+    -- UPDATE SUBSCRIPTIONS WITH CALCULATED METRICS
+    UPDATE subscriptions st
        SET active_consumers = v_active_consumers,
            active_consumers_weight = v_active_consumers_weight,
-           active_partitions = v_active_partitions,
+           active_partitions = (
+                SELECT COUNT(1)
+                  FROM cursors c
+                  JOIN partitions p ON c.partition_id = p.id
+                 WHERE c.subscription_id = st.id
+                   AND c.position < p.high_watermark
+           ),
            heartbeat_interval = v_heartbeat_interval
-     WHERE id = p_consumer_group_id;
-
+     WHERE st.consumer_group_id = p_consumer_group_id;
 END;


### PR DESCRIPTION
## Summary
- track heartbeat interval and activity metrics on `subscriptions` instead of `consumer_groups`
- rework stored procedures and Java domain/mappers to use subscription metrics
- document subscription-level statistics and update work-stealing description

## Testing
- `mvn -q test` *(fails: Previous attempts to find a Docker environment failed)*

------
https://chatgpt.com/codex/tasks/task_e_68913c3af9fc832fa3f45c81d4d555e7