### PR TITLE
Add topic_id to cursors and streamline related queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ erDiagram
 - **partitions**: per-topic shards that track a `high_watermark`.
 - **events**: append-only records stored per partition.
 - **subscription_topics**: links subscriptions to the topics they consume and stores precomputed statistics.
-- **cursors**: tracks the position per subscription and partition and stores the `subscription_id`
-  alongside the `subscription_topic_id` for join-free lookups. Each row is assigned a persistent
+- **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
+  `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent
   `random_key` used for evenly distributing the start position when acquiring leases.
 - **consumers**: registers each consumer’s `subscription_id`, `weight`, and `heartbeat_detected_at`.
 - **leases**: one row per `cursor` when a consumer holds a lease, tracking `subscription_id`, `topic_id`, and `partition_id` alongside `state` to support join-free lookups.

--- a/boxy-core/src/main/java/boxy/core/domain/Cursor.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Cursor.java
@@ -4,6 +4,7 @@ public record Cursor(
         long id,
         long subscriptionId,
         long subscriptionTopicId,
+        long topicId,
         long partitionId,
         int randomKey,
         long position) {

--- a/boxy-core/src/main/java/boxy/core/mapper/CursorMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/CursorMapper.java
@@ -12,6 +12,7 @@ public class CursorMapper implements RowMapper<Cursor> {
                 rs.getLong("id"),
                 rs.getLong("subscription_id"),
                 rs.getLong("subscription_topic_id"),
+                rs.getLong("topic_id"),
                 rs.getLong("partition_id"),
                 rs.getInt("random_key"),
                 rs.getLong("position"));

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -123,11 +123,13 @@ CREATE TABLE cursors (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
     subscription_id       BIGINT NOT NULL,
     subscription_topic_id BIGINT NOT NULL,
+    topic_id              BIGINT NOT NULL,
     partition_id          BIGINT NOT NULL,
     random_key            INT    NOT NULL,
     position              BIGINT NOT NULL DEFAULT 0,
     FOREIGN KEY (subscription_id)       REFERENCES subscriptions (id) ON DELETE CASCADE,
     FOREIGN KEY (subscription_topic_id) REFERENCES subscription_topics (id) ON DELETE CASCADE,
+    FOREIGN KEY (topic_id)             REFERENCES topics (id) ON DELETE CASCADE,
     FOREIGN KEY (partition_id)          REFERENCES partitions (id) ON DELETE CASCADE,
     CONSTRAINT u_cursors UNIQUE (subscription_topic_id, partition_id),
     INDEX idx_cursors__random_1 (random_key, id),
@@ -220,7 +222,7 @@ CREATE TABLE topics_cache (
 -- VIEW: unleased_cursors_view
 -- List cursors leases that are not leased and have active work to perform
 CREATE OR REPLACE ALGORITHM = MERGE VIEW unleased_cursors_view AS
-    SELECT c.*, p.topic_id
+    SELECT c.*
       FROM cursors c
       JOIN partitions p     ON c.partition_id = p.id
  LEFT JOIN leases l         ON c.id = l.cursor_id
@@ -237,7 +239,6 @@ CREATE OR REPLACE ALGORITHM = MERGE VIEW unleased_cursors_view AS
 CREATE OR REPLACE ALGORITHM = MERGE VIEW leased_cursors_view AS
     SELECT c.*, w.id AS consumer_id,
            l.cursor_id AS lease_id,
-           l.topic_id,
            l.acquired_at
      FROM consumers w
       JOIN leases l ON w.id = l.consumer_id

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_subscriptions__subscribe.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_subscriptions__subscribe.sql
@@ -19,8 +19,8 @@ BEGIN
 
         -- INSERT CURSORS
         SET v_id = LAST_INSERT_ID();
-        INSERT INTO cursors(subscription_topic_id, subscription_id, partition_id, random_key, position)
-             SELECT v_id, v_subscription_id, id, fn_random_int(), 0
+        INSERT INTO cursors(topic_id, subscription_topic_id, subscription_id, partition_id, random_key, position)
+             SELECT v_topic_id, v_id, v_subscription_id, id, fn_random_int(), 0
                FROM partitions
               WHERE topic_id = v_topic_id;
     COMMIT;


### PR DESCRIPTION
## Summary
- Store `topic_id` on each cursor row and cascade the foreign key
- Simplify cursor views to rely on the stored `topic_id`
- Populate `topic_id` when subscribing a topic and update domain mapping

## Testing
- `mvn -q test` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_68927b025098832fa9e7abbfe7746a82