### PR TITLE
Add sequence to events and remove publication timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,18 @@ Boxy is released under the **Apache License 2.0** and is under active developmen
 Liquibase migrations for the schema are under `boxy-db/src/main/resources/db/changelog`. The schema models:
 
 ```mermaid
-erDiagram
-    namespaces ||--o{ topics : owns
-    topics ||--o{ partitions : has
-    partitions ||--o{ events : stores
-    subscriptions ||--o{ subscription_topics : links
-    subscriptions ||--o{ cursors : positions
-    subscription_topics ||--o{ cursors : positions
-    cursors ||--o{ leases : locks
-    consumers ||--o{ leases : holds
+    erDiagram
+        namespaces ||--o{ topics : owns
+        topics ||--o{ partitions : has
+        partitions ||--o{ unprocessed_events : queues
+        partitions ||--o{ sequences : sequences
+        events ||--|| unprocessed_events : references
+        events ||--|| sequences : references
+        subscriptions ||--o{ subscription_topics : links
+        subscriptions ||--o{ cursors : positions
+        subscription_topics ||--o{ cursors : positions
+        cursors ||--o{ leases : locks
+        consumers ||--o{ leases : holds
 ```
 
 ### Key Tables and Views
@@ -90,7 +93,9 @@ erDiagram
 - **namespaces**: hierarchical containers for topics.
 - **topics**: belong to namespaces and declare a partition count.
 - **partitions**: per-topic shards that track a `high_watermark`.
-- **events**: append-only records stored per partition; includes an optional `sequence` column for custom ordering and no longer tracks publication timestamps.
+  - **events**: raw event payloads; partition and sequence metadata are tracked separately.
+  - **unprocessed_events**: queue linking newly published events to partitions until sequenced.
+  - **sequences**: per-partition sequence numbers referencing events.
 - **subscription_topics**: links subscriptions to the topics they consume and stores precomputed statistics.
 - **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
   `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ erDiagram
 - **namespaces**: hierarchical containers for topics.
 - **topics**: belong to namespaces and declare a partition count.
 - **partitions**: per-topic shards that track a `high_watermark`.
-- **events**: append-only records stored per partition.
+- **events**: append-only records stored per partition; includes an optional `sequence` column for custom ordering and no longer tracks publication timestamps.
 - **subscription_topics**: links subscriptions to the topics they consume and stores precomputed statistics.
 - **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
   `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent

--- a/boxy-core/src/main/java/boxy/core/domain/Event.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Event.java
@@ -2,7 +2,6 @@ package boxy.core.domain;
 
 public record Event(
         long id,
-        Long sequence,
         long partitionId,
         String data) {
 }

--- a/boxy-core/src/main/java/boxy/core/domain/Event.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Event.java
@@ -1,10 +1,8 @@
 package boxy.core.domain;
 
-import java.time.Instant;
-
 public record Event(
         long id,
-        Instant timestamp,
+        Long sequence,
         long partitionId,
         String data) {
 }

--- a/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
@@ -15,4 +15,8 @@ public final class EventRepository extends BaseRepository {
     public void publish(final long partitionId, final String data) {
         update("{CALL sp_events__publish_advanced(?,?)}", partitionId, data);
     }
+
+    public void sequence(final long topicId, final int batchSize) {
+        update("{CALL sp_events__sequence(?,?)}", topicId, batchSize);
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/EventRepository.java
@@ -16,7 +16,8 @@ public final class EventRepository extends BaseRepository {
         update("{CALL sp_events__publish_advanced(?,?)}", partitionId, data);
     }
 
-    public void sequence(final long topicId, final int batchSize) {
-        update("{CALL sp_events__sequence(?,?)}", topicId, batchSize);
+    public int sequence(final int batchSize) {
+        return queryOne("{CALL sp_events__sequence(?)}", rs -> rs.getInt("sequenced_events"), batchSize)
+                .orElse(0);
     }
 }

--- a/boxy-core/src/test/java/boxy/core/it/ProcessorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/ProcessorIT.java
@@ -34,6 +34,7 @@ public class ProcessorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         // PUBLISH
         eventRepository.publish(PATH_A, TOPIC_A, "partitionKey", DATA);
+        eventRepository.sequence(100);
         // VALIDATE
         final var leasable = cursorRepository.findLeasable(subscriptionId, 100, 0);
         assertThat(leasable).hasSize(1);
@@ -54,6 +55,7 @@ public class ProcessorIT extends BaseIT {
         eventRepository.publish(PATH_B, TOPIC_C, "pk6", DATA);
         eventRepository.publish(PATH_B, TOPIC_D, "pk7", DATA);
         eventRepository.publish(PATH_B, TOPIC_D, "pk8", DATA);
+        eventRepository.sequence(100);
         // VALIDATE
         final var leasable = cursorRepository.findLeasable(100, 0);
         assertThat(leasable).hasSize(16);

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.changelog-master.xml
@@ -137,12 +137,16 @@
                  relativeToChangelogFile="true"
                  splitStatements="false"
                  stripComments="false"/>
-        <sqlFile path="sp/sp_events__publish_multi.sql"
-                 relativeToChangelogFile="true"
-                 splitStatements="false"
-                 stripComments="false"/>
+         <sqlFile path="sp/sp_events__publish_multi.sql"
+                   relativeToChangelogFile="true"
+                   splitStatements="false"
+                   stripComments="false"/>
+         <sqlFile path="sp/sp_events__sequence.sql"
+                   relativeToChangelogFile="true"
+                   splitStatements="false"
+                   stripComments="false"/>
 
-        <!-- CURSORS -->
+          <!-- CURSORS -->
         <sqlFile path="sp/sp_cursors__commit.sql"
                  relativeToChangelogFile="true"
                  splitStatements="false"

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -201,10 +201,10 @@ CREATE TABLE IF NOT EXISTS unprocessed_events (
   ROW_FORMAT=COMPACT;
 
 CREATE TABLE IF NOT EXISTS sequences (
-    partition_id BIGINT NOT NULL,
     sequence     BIGINT AUTO_INCREMENT,
+    partition_id BIGINT NOT NULL,
     event_id     BIGINT NOT NULL,
-    PRIMARY KEY (partition_id, sequence, event_id)
+    PRIMARY KEY (sequence, partition_id, event_id)
 ) ENGINE=InnoDB
   ROW_FORMAT=COMPACT;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -194,17 +194,24 @@ CREATE TABLE leases (
     COLLATE=utf8mb4_bin
     COMMENT='Implements distributed locking for processing cursor positions—tracks consumer, version, and state';
 
-CREATE TABLE events (
-    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
-    sequence        BIGINT DEFAULT NULL,
-    partition_id    BIGINT NOT NULL,
-    data            JSON   NOT NULL,
-    INDEX idx_events__sequence(sequence)
+CREATE TABLE IF NOT EXISTS unprocessed_events (
+    id           BIGINT PRIMARY KEY,
+    partition_id BIGINT NOT NULL
 ) ENGINE=InnoDB
-    DEFAULT CHARSET=utf8mb4
-    COLLATE=utf8mb4_bin
-    ROW_FORMAT = DYNAMIC
-    COMMENT='Append-only event store per partition; JSON payloads in sequence order';
+  ROW_FORMAT=COMPACT;
+
+CREATE TABLE IF NOT EXISTS sequences (
+    partition_id BIGINT NOT NULL,
+    sequence     BIGINT AUTO_INCREMENT,
+    event_id     BIGINT NOT NULL,
+    PRIMARY KEY (partition_id, sequence, event_id)
+) ENGINE=InnoDB
+  ROW_FORMAT=COMPACT;
+
+CREATE TABLE IF NOT EXISTS events (
+    id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    data LONGBLOB NOT NULL
+) ENGINE=InnoDB;
 
 CREATE TABLE topics_cache (
   path_hash    BINARY(16)    NOT NULL,

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -196,10 +196,10 @@ CREATE TABLE leases (
 
 CREATE TABLE events (
     id              BIGINT AUTO_INCREMENT PRIMARY KEY,
-    published_at    DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL,
+    sequence        BIGINT DEFAULT NULL,
     partition_id    BIGINT NOT NULL,
     data            JSON   NOT NULL,
-    INDEX idx_events__cover(partition_id, id)
+    INDEX idx_events__sequence(sequence)
 ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_bin

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish.sql
@@ -2,12 +2,13 @@ CREATE PROCEDURE sp_events__publish(
     IN p_path VARCHAR(4000),
     IN p_topic VARCHAR(500),
     IN p_key VARCHAR(255),
-    IN p_data JSON)
+    IN p_data LONGBLOB)
 BEGIN
     DECLARE v_partition_number INT;
     DECLARE v_partitions INT;
     DECLARE v_partition_id BIGINT;
     DECLARE v_topic_id BIGINT;
+    DECLARE v_event_id BIGINT;
 
     -- RESOLVE THE TOPIC AND PARTITION COUNT
     CALL sp_topics__cache_get(p_path, p_topic, v_topic_id, v_partitions);
@@ -15,5 +16,7 @@ BEGIN
     SET v_partition_id = fn_resolve_partition_id(v_topic_id, v_partition_number);
 
     -- EVENT PUBLICATION
-    INSERT INTO events(partition_id, data) VALUES (v_partition_id, p_data);
+    INSERT INTO events(data) VALUES (p_data);
+    SET v_event_id = LAST_INSERT_ID();
+    INSERT INTO unprocessed_events(id, partition_id) VALUES (v_event_id, v_partition_id);
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish.sql
@@ -8,7 +8,6 @@ BEGIN
     DECLARE v_partitions INT;
     DECLARE v_partition_id BIGINT;
     DECLARE v_topic_id BIGINT;
-    DECLARE v_sequence BIGINT;
 
     -- RESOLVE THE TOPIC AND PARTITION COUNT
     CALL sp_topics__cache_get(p_path, p_topic, v_topic_id, v_partitions);
@@ -17,8 +16,4 @@ BEGIN
 
     -- EVENT PUBLICATION
     INSERT INTO events(partition_id, data) VALUES (v_partition_id, p_data);
-
-    -- HWM UPDATE
-    SET v_sequence = LAST_INSERT_ID();
-    UPDATE partitions SET high_watermark = v_sequence WHERE id = v_partition_id AND high_watermark < v_sequence;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish_advanced.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish_advanced.sql
@@ -1,8 +1,11 @@
 CREATE PROCEDURE sp_events__publish_advanced(
     IN p_partition_id BIGINT,
-    IN p_data JSON)
+    IN p_data LONGBLOB)
 BEGIN
+    DECLARE v_event_id BIGINT;
     -- EVENT PUBLICATION
-    INSERT INTO events(partition_id, data) VALUES (p_partition_id, p_data);
+    INSERT INTO events(data) VALUES (p_data);
+    SET v_event_id = LAST_INSERT_ID();
+    INSERT INTO unprocessed_events(id, partition_id) VALUES (v_event_id, p_partition_id);
 END;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish_advanced.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__publish_advanced.sql
@@ -2,12 +2,7 @@ CREATE PROCEDURE sp_events__publish_advanced(
     IN p_partition_id BIGINT,
     IN p_data JSON)
 BEGIN
-    DECLARE v_sequence BIGINT;
-
     -- EVENT PUBLICATION
     INSERT INTO events(partition_id, data) VALUES (p_partition_id, p_data);
-    -- HWM UPDATE
-    SET v_sequence = LAST_INSERT_ID();
-    UPDATE partitions SET high_watermark = v_sequence WHERE id = p_partition_id AND high_watermark < v_sequence;
 END;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
@@ -1,0 +1,51 @@
+CREATE PROCEDURE sp_events__sequence(
+    IN p_topic_id BIGINT,
+    IN p_batch_size INT)
+BEGIN
+    DECLARE v_next_sequence BIGINT;
+
+    -- Determine starting sequence for this topic
+    SELECT IFNULL(MAX(e.sequence), 0)
+      INTO v_next_sequence
+      FROM events e
+      JOIN partitions p ON e.partition_id = p.id
+     WHERE p.topic_id = p_topic_id;
+
+    -- Collect events to update
+    CREATE TEMPORARY TABLE tmp_events (
+        event_id BIGINT,
+        partition_id BIGINT
+    ) ENGINE=MEMORY;
+
+    INSERT INTO tmp_events (event_id, partition_id)
+    SELECT e.id, e.partition_id
+      FROM events e
+      JOIN partitions p ON e.partition_id = p.id
+     WHERE p.topic_id = p_topic_id
+       AND e.sequence IS NULL
+     ORDER BY e.id ASC
+     LIMIT p_batch_size
+     FOR UPDATE;
+
+    -- Assign sequence numbers in id order
+    SET @seq := v_next_sequence;
+    UPDATE events e
+    JOIN (
+        SELECT event_id
+          FROM tmp_events
+         ORDER BY event_id
+    ) t ON e.id = t.event_id
+    SET e.sequence = (@seq := @seq + 1);
+
+    -- Update high watermarks for affected partitions
+    UPDATE partitions p
+    JOIN (
+        SELECT e.partition_id, MAX(e.sequence) AS max_seq
+          FROM events e
+          JOIN tmp_events t ON e.id = t.event_id
+         GROUP BY e.partition_id
+    ) s ON p.id = s.partition_id
+    SET p.high_watermark = GREATEST(p.high_watermark, s.max_seq);
+
+    DROP TEMPORARY TABLE tmp_events;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
@@ -1,51 +1,39 @@
-CREATE PROCEDURE sp_events__sequence(
-    IN p_topic_id BIGINT,
-    IN p_batch_size INT)
+CREATE PROCEDURE sp_events__sequence(IN p_batch_size INT)
 BEGIN
-    DECLARE v_next_sequence BIGINT;
+    DECLARE v_sequenced_events INT DEFAULT 0;
+    CREATE TEMPORARY TABLE IF NOT EXISTS temp_claimed_ids (
+        id BIGINT PRIMARY KEY,
+        partition_id BIGINT NOT NULL
+    ) ENGINE = MEMORY;   
+    TRUNCATE TABLE temp_claimed_ids;
 
-    -- Determine starting sequence for this topic
-    SELECT IFNULL(MAX(e.sequence), 0)
-      INTO v_next_sequence
-      FROM events e
-      JOIN partitions p ON e.partition_id = p.id
-     WHERE p.topic_id = p_topic_id;
+    START TRANSACTION;
 
-    -- Collect events to update
-    CREATE TEMPORARY TABLE tmp_events (
-        event_id BIGINT,
-        partition_id BIGINT
-    ) ENGINE=MEMORY;
+        INSERT INTO temp_claimed_ids (id, partition_id) 
+            SELECT id, partition_id 
+            FROM unprocessed_events 
+            ORDER BY ID LIMIT p_batch_size;
 
-    INSERT INTO tmp_events (event_id, partition_id)
-    SELECT e.id, e.partition_id
-      FROM events e
-      JOIN partitions p ON e.partition_id = p.id
-     WHERE p.topic_id = p_topic_id
-       AND e.sequence IS NULL
-     ORDER BY e.id ASC
-     LIMIT p_batch_size
-     FOR UPDATE;
+        INSERT INTO sequences (event_id, partition_id) 
+            SELECT id, partition_id FROM temp_claimed_ids 
+            ORDER BY id;
 
-    -- Assign sequence numbers in id order
-    SET @seq := v_next_sequence;
-    UPDATE events e
-    JOIN (
-        SELECT event_id
-          FROM tmp_events
-         ORDER BY event_id
-    ) t ON e.id = t.event_id
-    SET e.sequence = (@seq := @seq + 1);
+        SELECT ROW_COUNT() INTO v_sequenced_events;
 
-    -- Update high watermarks for affected partitions
-    UPDATE partitions p
-    JOIN (
-        SELECT e.partition_id, MAX(e.sequence) AS max_seq
-          FROM events e
-          JOIN tmp_events t ON e.id = t.event_id
-         GROUP BY e.partition_id
-    ) s ON p.id = s.partition_id
-    SET p.high_watermark = GREATEST(p.high_watermark, s.max_seq);
+        -- CAREFUL!!: 
+        -- Changing this join can impact the performance of the sequencer.
+        DELETE ue FROM temp_claimed_ids b 
+            STRAIGHT_JOIN unprocessed_events ue ON b.id = ue.id;
 
-    DROP TEMPORARY TABLE tmp_events;
+        UPDATE partitions p
+        JOIN (
+            SELECT s.partition_id, MAX(s.sequence) AS max_sequence
+            FROM sequences s
+            JOIN temp_claimed_ids t ON s.event_id = t.id
+            GROUP BY s.partition_id
+        ) seqs ON p.id = seqs.partition_id
+        SET p.high_watermark = GREATEST(p.high_watermark, seqs.max_sequence);
+
+    COMMIT;
+    SELECT v_sequenced_events AS sequenced_events;
 END;


### PR DESCRIPTION
## Summary
- drop `published_at` from events
- introduce nullable `sequence` column with index
- remove obsolete `idx_events__cover` index
- align Event model and docs with new column
- remove high-watermark updates from event publishing procedures

## Testing
- `mvn -q test` *(fails: Could not find a valid Docker environment)*
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68988c5513d8832fa5bd6950abcf1f42