### PR TITLE
Batch sequence events per partition

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -166,8 +166,8 @@ CREATE TABLE IF NOT EXISTS unprocessed_events (
 CREATE TABLE IF NOT EXISTS sequences (
     sequence     BIGINT AUTO_INCREMENT,
     partition_id BIGINT NOT NULL,
-    event_id     BIGINT NOT NULL,
-    PRIMARY KEY (sequence, partition_id, event_id)
+    event_ids    JSON NOT NULL,
+    PRIMARY KEY (sequence, partition_id)
 ) ENGINE=InnoDB
   ROW_FORMAT=COMPACT;
 

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
@@ -4,35 +4,43 @@ BEGIN
     CREATE TEMPORARY TABLE IF NOT EXISTS temp_claimed_ids (
         id BIGINT PRIMARY KEY,
         partition_id BIGINT NOT NULL
-    ) ENGINE = MEMORY;   
+    ) ENGINE = MEMORY;
     TRUNCATE TABLE temp_claimed_ids;
 
     START TRANSACTION;
 
-        INSERT INTO temp_claimed_ids (id, partition_id) 
-            SELECT id, partition_id 
-            FROM unprocessed_events 
-            ORDER BY ID LIMIT p_batch_size;
+        INSERT INTO temp_claimed_ids (id, partition_id)
+            SELECT id, partition_id FROM (
+                SELECT id,
+                       partition_id,
+                       ROW_NUMBER() OVER (PARTITION BY partition_id ORDER BY id) AS rn
+                FROM unprocessed_events
+            ) e
+            WHERE e.rn <= p_batch_size;
 
-        INSERT INTO sequences (event_id, partition_id) 
-            SELECT id, partition_id FROM temp_claimed_ids 
-            ORDER BY id;
+        INSERT INTO sequences (partition_id, event_ids)
+            SELECT partition_id,
+                   JSON_ARRAYAGG(id ORDER BY id) AS event_ids
+            FROM temp_claimed_ids
+            GROUP BY partition_id
+            ORDER BY partition_id;
 
-        SELECT ROW_COUNT() INTO v_sequenced_events;
+        SELECT COUNT(*) INTO v_sequenced_events FROM temp_claimed_ids;
 
-        -- CAREFUL!!: 
+        -- CAREFUL!!:
         -- Changing this join can impact the performance of the sequencer.
-        DELETE ue FROM temp_claimed_ids b 
+        DELETE ue FROM temp_claimed_ids b
             STRAIGHT_JOIN unprocessed_events ue ON b.id = ue.id;
 
         UPDATE partitions p
         JOIN (
             SELECT s.partition_id, MAX(s.sequence) AS max_sequence
             FROM sequences s
-            JOIN temp_claimed_ids t ON s.event_id = t.id
+            JOIN (SELECT DISTINCT partition_id FROM temp_claimed_ids) t
+                ON s.partition_id = t.partition_id
             GROUP BY s.partition_id
         ) seqs ON p.id = seqs.partition_id
-        SET p.high_watermark = GREATEST(p.high_watermark, seqs.max_sequence);
+        SET p.high_watermark = seqs.max_sequence;
 
     COMMIT;
     SELECT v_sequenced_events AS sequenced_events;


### PR DESCRIPTION
## Summary
- Store arrays of event ids in the `sequences` table
- Sequence events in batches per partition, aggregating ids into JSON
- Simplify partitions high-watermark update to use new batch sequences

## Testing
- `mvn -pl boxy-db test`

------
https://chatgpt.com/codex/tasks/task_e_68a7676111bc832faf047a6a20922832