### PR TITLE
Use stored event_count to streamline event polling

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -171,6 +171,7 @@ CREATE TABLE IF NOT EXISTS sequences (
     sequence     BIGINT AUTO_INCREMENT,
     partition_id BIGINT NOT NULL,
     event_ids    JSON NOT NULL,
+    event_count  SMALLINT NOT NULL,
     PRIMARY KEY (sequence, partition_id),
     INDEX idx_sequences__partition_sequence (partition_id, sequence)
 ) ENGINE=InnoDB

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -15,15 +15,15 @@ BEGIN
             c.partition_id,
             s.sequence,
             s.event_ids,
-            JSON_LENGTH(s.event_ids) AS event_count,
-            SUM(JSON_LENGTH(s.event_ids)) OVER (
+            s.event_count,
+            SUM(s.event_count) OVER (
                 ORDER BY (c.random_key >= v_start_key) DESC, c.random_key, c.id
                 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
             ) AS cumulative_events
         FROM cursors c
         JOIN partitions p ON p.id = c.partition_id
         JOIN LATERAL (
-            SELECT s.sequence, s.event_ids
+            SELECT s.sequence, s.event_ids, s.event_count
             FROM sequences s FORCE INDEX (idx_sequences__partition_sequence)
             WHERE s.partition_id = c.partition_id
               AND s.sequence > c.position

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
@@ -24,9 +24,10 @@ BEGIN
         -- WE CAN'T USE JSON_ARRAYAGG(id ORDER BY id) ON MYSQL 8.0.x
         -- WE CAN OPTIMIZE THIS TO USE JSON_ARRAYAGG WHEN WE MOVE TO A NEWER VERSION AS THE MINIMUM
         SET SESSION group_concat_max_len = p_batch_size * 2500;
-        INSERT INTO sequences (partition_id, event_ids)
+        INSERT INTO sequences (partition_id, event_ids, event_count)
              SELECT partition_id,
-                    CAST(CONCAT('[', GROUP_CONCAT(id ORDER BY id SEPARATOR ','), ']') AS JSON) AS event_ids
+                    CAST(CONCAT('[', GROUP_CONCAT(id ORDER BY id SEPARATOR ','), ']') AS JSON) AS event_ids,
+                    COUNT(*) AS event_count
                FROM temp_claimed_ids
               GROUP BY partition_id;
 


### PR DESCRIPTION
## Summary
- Store the number of events in each sequence row in a new `event_count` column
- Populate `event_count` during sequencing
- Use the `event_count` column in `sp_events__poll` instead of `JSON_LENGTH`

## Testing
- `mvn -pl boxy-db test`

------
https://chatgpt.com/codex/tasks/task_e_68b467c9f2d0832fa4483e9ac911a5ab