### PR TITLE
Simplify sequencing to per-event rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Liquibase migrations for the schema are under `boxy-db/src/main/resources/db/cha
 - **partitions**: per-topic shards that track a `high_watermark`.
   - **events**: raw event payloads; partition and sequence metadata are tracked separately.
   - **unprocessed_events**: queue linking newly published events to partitions until sequenced.
-  - **sequences**: per-partition sequence numbers referencing events.
+  - **sequences**: per-partition sequence numbers referencing single events (one row per event).
 - **subscription_topics**: links subscriptions to the topics they consume and stores precomputed statistics.
 - **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
   `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent

--- a/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
@@ -125,62 +125,6 @@ class EventPollIT extends BaseIT {
         assertThat(polled).hasSize(3);
     }
 
-    @Test
-    void poll_returnsOversizedSequence() throws SQLException {
-        final long subscriptionId = data.subscriptions().getFirst().id();
-        final long partitionId =
-                partitionRepository.find(TestData.PATH_A, TestData.TOPIC_A, 0).orElseThrow().id();
-        final String consumerId = "consumer-3";
-
-        eventRepository.publish(partitionId, "{}");
-        eventRepository.publish(partitionId, "{}");
-        eventRepository.publish(partitionId, "{}");
-        awaitSequencer();
-
-        final List<Long> polled = new ArrayList<>();
-        try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 2);
-            try (var rs = poll.executeQuery()) {
-                while (rs.next()) {
-                    polled.add(rs.getLong("event_id"));
-                }
-            }
-        }
-
-        assertThat(polled).hasSize(3);
-    }
-
-    @Test
-    void poll_returnsOnlyFirstOversizedSequence() throws SQLException {
-        final long subscriptionId = data.subscriptions().getFirst().id();
-        final long partitionId =
-                partitionRepository.find(TestData.PATH_A, TestData.TOPIC_A, 0).orElseThrow().id();
-        final String consumerId = "consumer-4";
-
-        for (int i = 0; i < 20; i++) {
-            eventRepository.publish(partitionId, "{}");
-        }
-        awaitSequencer();
-
-        final List<Long> polled = new ArrayList<>();
-        try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 3);
-            try (var rs = poll.executeQuery()) {
-                while (rs.next()) {
-                    polled.add(rs.getLong("event_id"));
-                }
-            }
-        }
-
-        assertThat(polled).hasSize(20);
-    }
-
     private void awaitSequencer() {
         try {
             Thread.sleep(1000);

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -170,8 +170,7 @@ CREATE TABLE IF NOT EXISTS unprocessed_events (
 CREATE TABLE IF NOT EXISTS sequences (
     sequence     BIGINT AUTO_INCREMENT,
     partition_id BIGINT NOT NULL,
-    event_ids    JSON NOT NULL,
-    event_count  SMALLINT NOT NULL,
+    event_id     BIGINT NOT NULL,
     PRIMARY KEY (sequence, partition_id),
     INDEX idx_sequences__partition_sequence (partition_id, sequence)
 ) ENGINE=InnoDB

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/event_sequencer.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/event_sequencer.sql
@@ -2,4 +2,4 @@ CREATE EVENT event_sequencer
     ON SCHEDULE EVERY 1 MINUTE
     ON COMPLETION PRESERVE
     ENABLE
-    DO CALL sp_events__sequence_loop(100);
+    DO CALL sp_events__sequence_loop(1000);

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -14,16 +14,14 @@ BEGIN
             c.id AS cursor_id,
             c.partition_id,
             s.sequence,
-            s.event_ids,
-            s.event_count,
-            SUM(s.event_count) OVER (
+            s.event_id,
+            ROW_NUMBER() OVER (
                 ORDER BY (c.random_key >= v_start_key) DESC, c.random_key, c.id
-                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-            ) AS cumulative_events
+            ) AS row_num
         FROM cursors c
         JOIN partitions p ON p.id = c.partition_id
         JOIN LATERAL (
-            SELECT s.sequence, s.event_ids, s.event_count
+            SELECT s.sequence, s.event_id
             FROM sequences s FORCE INDEX (idx_sequences__partition_sequence)
             WHERE s.partition_id = c.partition_id
               AND s.sequence > c.position
@@ -35,9 +33,9 @@ BEGIN
           AND p.high_watermark > c.position
     ),
     selected AS (
-        SELECT cursor_id, partition_id, sequence, event_ids
+        SELECT cursor_id, partition_id, sequence, event_id
         FROM candidate
-        WHERE cumulative_events - event_count < p_batch_size
+        WHERE row_num <= p_batch_size
     )
     SELECT
         COALESCE(
@@ -46,7 +44,7 @@ BEGIN
                     'cursor_id',    cursor_id,
                     'partition_id', partition_id,
                     'sequence',     sequence,
-                    'event_ids',    event_ids
+                    'event_id',     event_id
                 )
             ),
             JSON_ARRAY()
@@ -75,8 +73,7 @@ BEGIN
             cursor_id    BIGINT PATH '$.cursor_id',
             partition_id BIGINT PATH '$.partition_id',
             sequence     BIGINT PATH '$.sequence',
-            NESTED PATH '$.event_ids[*]'
-                COLUMNS (event_id BIGINT PATH '$')
+            event_id     BIGINT PATH '$.event_id'
         )
     ) jt
     JOIN cursors c

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -6,9 +6,16 @@ CREATE PROCEDURE sp_events__poll(
 BEGIN
     DECLARE v_start_key INT DEFAULT fn_random_int();
     DECLARE v_now       DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3);
-    DECLARE v_sel       JSON;  -- holds the selected rows once
 
-    /* 1) Build the selected set once into v_sel (no result set emitted) */
+    CREATE TEMPORARY TABLE IF NOT EXISTS temp_polled_events (
+        cursor_id    BIGINT PRIMARY KEY,
+        partition_id BIGINT NOT NULL,
+        sequence     BIGINT NOT NULL,
+        event_id     BIGINT NOT NULL
+    ) ENGINE = MEMORY;
+    DELETE FROM temp_polled_events;
+
+    /* 1) Materialize the candidate rows up to the requested batch size */
     WITH candidate AS (
         SELECT
             c.id AS cursor_id,
@@ -31,54 +38,30 @@ BEGIN
         WHERE c.subscription_id = p_subscription_id
           AND (c.locked_until IS NULL OR c.locked_until < v_now OR c.locked_by = p_consumer_id)
           AND p.high_watermark > c.position
-    ),
-    selected AS (
-        SELECT cursor_id, partition_id, sequence, event_id
-        FROM candidate
-        WHERE row_num <= p_batch_size
     )
-    SELECT
-        COALESCE(
-            JSON_ARRAYAGG(
-                JSON_OBJECT(
-                    'cursor_id',    cursor_id,
-                    'partition_id', partition_id,
-                    'sequence',     sequence,
-                    'event_id',     event_id
-                )
-            ),
-            JSON_ARRAY()
-        )
-    INTO v_sel
-    FROM selected;
+    INSERT INTO temp_polled_events (cursor_id, partition_id, sequence, event_id)
+    SELECT cursor_id, partition_id, sequence, event_id
+    FROM candidate
+    WHERE row_num <= p_batch_size;
 
     /* 2) Lock the selected cursors */
     UPDATE cursors c
-    JOIN JSON_TABLE(v_sel, '$[*]'
-        COLUMNS (cursor_id BIGINT PATH '$.cursor_id')
-    ) sel ON sel.cursor_id = c.id
+    JOIN temp_polled_events sel ON sel.cursor_id = c.id
     SET c.locked_by    = p_consumer_id,
         c.locked_until = DATE_ADD(v_now, INTERVAL 3 SECOND)
     WHERE c.locked_until IS NULL OR c.locked_until < v_now OR c.locked_by = p_consumer_id;
 
     /* 3) Return the events for rows we actually hold now */
     SELECT
-        jt.cursor_id,
+        sel.cursor_id,
         c.partition_id,
-        jt.sequence,
+        sel.sequence,
         e.id   AS event_id,
         e.data
-    FROM JSON_TABLE(v_sel, '$[*]'
-        COLUMNS (
-            cursor_id    BIGINT PATH '$.cursor_id',
-            partition_id BIGINT PATH '$.partition_id',
-            sequence     BIGINT PATH '$.sequence',
-            event_id     BIGINT PATH '$.event_id'
-        )
-    ) jt
+    FROM temp_polled_events sel
     JOIN cursors c
-      ON c.id = jt.cursor_id
+      ON c.id = sel.cursor_id
      AND c.locked_by = p_consumer_id
     JOIN events e
-      ON e.id = jt.event_id;
+      ON e.id = sel.event_id;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__sequence.sql
@@ -20,16 +20,11 @@ BEGIN
             ) e
             WHERE e.rn <= p_batch_size;
 
-        -- INSERT THE SEQUENCE BATCHES
-        -- WE CAN'T USE JSON_ARRAYAGG(id ORDER BY id) ON MYSQL 8.0.x
-        -- WE CAN OPTIMIZE THIS TO USE JSON_ARRAYAGG WHEN WE MOVE TO A NEWER VERSION AS THE MINIMUM
-        SET SESSION group_concat_max_len = p_batch_size * 2500;
-        INSERT INTO sequences (partition_id, event_ids, event_count)
-             SELECT partition_id,
-                    CAST(CONCAT('[', GROUP_CONCAT(id ORDER BY id SEPARATOR ','), ']') AS JSON) AS event_ids,
-                    COUNT(*) AS event_count
-               FROM temp_claimed_ids
-              GROUP BY partition_id;
+        -- INSERT INDIVIDUAL SEQUENCES
+        INSERT INTO sequences (partition_id, event_id)
+            SELECT partition_id, id
+            FROM temp_claimed_ids
+            ORDER BY partition_id, id;
 
         -- DETERMINE IF THERE WERE ANY SEQUENCED EVENTS
         SET v_has_events = IF(ROW_COUNT() > 0, 1, 0);
@@ -39,14 +34,13 @@ BEGIN
         DELETE ue FROM temp_claimed_ids b
             STRAIGHT_JOIN unprocessed_events ue ON b.id = ue.id;
 
-        -- UPDATE HIGH WATERMARKS
+        -- UPDATE HIGH WATERMARKS ONCE PER PARTITION USING JUST-INSERTED ROWS
         UPDATE partitions p
         JOIN (
             SELECT s.partition_id, MAX(s.sequence) AS max_sequence
-            FROM sequences s
-            JOIN (SELECT DISTINCT partition_id FROM temp_claimed_ids) t
-                ON s.partition_id = t.partition_id
-            GROUP BY s.partition_id
+              FROM sequences s
+              JOIN temp_claimed_ids t ON s.event_id = t.id
+             GROUP BY s.partition_id
         ) seqs ON p.id = seqs.partition_id
         SET p.high_watermark = seqs.max_sequence;
 


### PR DESCRIPTION
## Summary
- change the sequences table to store one event id per row and drop the event_count column
- simplify sp_events__sequence and sp_events__poll to match the per-event model and bump the sequencer batch size to 1000
- update README and integration tests to reflect the new sequencing behavior

## Testing
- `mvn -pl boxy-core test` *(fails: could not resolve mvsm:boxy-db:jar:1.0-SNAPSHOT)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ef0701b4832f8e591f28449e6a89)