### PR TITLE
Implement consumer GC logic

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__gc.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__gc.sql
@@ -1,4 +1,19 @@
 CREATE PROCEDURE sp_consumers__gc()
 BEGIN
     DECLARE v_timestamp TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3);
+
+    START TRANSACTION;
+
+    DELETE
+      FROM consumer_subscriptions
+     WHERE consumer_id IN (
+               SELECT id
+                 FROM consumers
+                WHERE heartbeat_deadline <= v_timestamp);
+
+    DELETE
+      FROM consumers
+     WHERE heartbeat_deadline <= v_timestamp;
+
+    COMMIT;
 END;


### PR DESCRIPTION
## Summary
- wrap the statements inside `sp_consumers__gc` in an explicit transaction
- ensure the deletes of subscriptions and consumers are executed atomically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc87819d0832f82693ee55cdb3aa4)