### PR TITLE
Fix JSON array aggregation in consumer registration stored procedure

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -48,7 +48,8 @@ BEGIN
         (SELECT COUNT(*) FROM topic_input),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 0),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 1 AND topic_id IS NULL),
-        (SELECT JSON_ARRAYAGG(DISTINCT topic_id ORDER BY topic_id) FROM resolved WHERE topic_id IS NOT NULL)
+        (SELECT JSON_ARRAYAGG(topic_id ORDER BY topic_id)
+           FROM (SELECT DISTINCT topic_id FROM resolved WHERE topic_id IS NOT NULL) AS deduped)
     INTO v_input_count, v_invalid_paths, v_missing_topics, v_topic_ids;
 
     IF v_input_count = 0 THEN


### PR DESCRIPTION
## Summary
- fix JSON array aggregation syntax in `sp_consumers__register` by deduplicating topic ids in a subquery
- preserve ordered topic id aggregation while avoiding unsupported DISTINCT usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2731a974832f89622978c89dcb65)