### PR TITLE
Align consumer protocol procedures and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Liquibase migrations for the schema are under `boxy-db/src/main/resources/db/cha
 - **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
   `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent
   `random_key` used for evenly distributing start positions among consumers.
-- **consumers**: registers each consumer’s `subscription_id`, `weight`, `heartbeat_detected_at`, and `topic_ids` JSON array of topic identifiers.
+- **sessions**: registers each consumer session’s `subscription_id`, `weight`, `heartbeat_detected_at`, and `topic_ids` JSON array of topic identifiers.
 - **subscriptions**: defines logical groups of consumers.
 - **topics_cache**: in-memory table for quick topic lookups.
 
@@ -134,7 +134,7 @@ classDiagram
 
 ## Heartbeats
 
-Consumer-level heartbeat (in the consumers table) remains independent of per-partition state.
+Consumer-level heartbeat (in the sessions table) remains independent of per-partition state.
 
 Rather than every consumer polling for events N-times per seconds, we define:
 

--- a/boxy-core/src/main/java/boxy/core/domain/Lease.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Lease.java
@@ -4,6 +4,6 @@ import java.time.Instant;
 
 public record Lease(
         long cursorId,
-        String consumerId,
+        String sessionId,
         Instant lockedUntil) {
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/LeaseMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/LeaseMapper.java
@@ -14,7 +14,7 @@ public class LeaseMapper implements RowMapper<Lease> {
         final Instant lockedUntilInstant = lockedUntil == null ? null : lockedUntil.toInstant();
         return new Lease(
                 rs.getLong("cursor_id"),
-                rs.getString("consumer_id"),
+                rs.getString("session_id"),
                 lockedUntilInstant);
     }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/ConsumerRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/ConsumerRepository.java
@@ -15,20 +15,20 @@ public final class ConsumerRepository extends BaseRepository {
         super(ds);
     }
 
-    public Optional<Consumer> find(final String id) {
-        return queryOne("SELECT * FROM consumers WHERE id = ?", CONSUMER_MAPPER, id);
+    public Optional<Consumer> find(final String sessionId) {
+        return queryOne("SELECT * FROM sessions WHERE id = ?", CONSUMER_MAPPER, sessionId);
     }
 
     public List<Consumer> findAll(final int limit, final int offset) {
-        return query("SELECT * FROM consumers ORDER BY id LIMIT ? OFFSET ?", CONSUMER_MAPPER, limit, offset);
+        return query("SELECT * FROM sessions ORDER BY id LIMIT ? OFFSET ?", CONSUMER_MAPPER, limit, offset);
     }
 
-    public void register(final String consumerId, final String subscriptionName, final List<String> topicPaths) {
-        update("{CALL sp_consumers__register(?, ?, ?)}", consumerId, subscriptionName, toJsonArray(topicPaths));
+    public void register(final String sessionId, final String subscriptionName, final List<String> topicPaths) {
+        update("{CALL sp_consumers__register(?, ?, ?)}", sessionId, subscriptionName, toJsonArray(topicPaths));
     }
 
-    public void deregister(final String id) {
-        update("{CALL sp_consumers__deregister(?)}", id);
+    public void deregister(final String sessionId) {
+        update("{CALL sp_consumers__deregister(?)}", sessionId);
     }
 
     private String toJsonArray(final List<String> values) {

--- a/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
@@ -5,7 +5,9 @@ import boxy.core.domain.Cursor;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class CursorRepository extends BaseRepository {
 
@@ -15,8 +17,8 @@ public final class CursorRepository extends BaseRepository {
         super(ds);
     }
 
-    public void commit(final long id, final long position) {
-        update("{CALL sp_cursors__commit(?,?)}", id, position);
+    public void commit(final String sessionId, final Map<Long, Long> positions) {
+        update("{CALL sp_cursors__commit(?,?)}", sessionId, toJsonObject(positions));
     }
 
     public Optional<Cursor> find(final long id) {
@@ -33,4 +35,12 @@ public final class CursorRepository extends BaseRepository {
                 CURSOR_MAPPER, subscriptionId);
     }
 
+    private String toJsonObject(final Map<Long, Long> positions) {
+        return positions.entrySet()
+                .stream()
+                .map(entry -> "\"" + entry.getKey() + "\":" + entry.getValue())
+                .collect(Collectors.joining(",", "{", "}"));
+    }
+
 }
+

--- a/boxy-core/src/main/java/boxy/core/repository/LeaseRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/LeaseRepository.java
@@ -19,7 +19,7 @@ public final class LeaseRepository extends BaseRepository {
         return queryOne("SELECT * FROM leases WHERE cursor_id = ?", LEASE_MAPPER, cursorId);
     }
 
-    public List<Lease> findByConsumer(final String consumerId) {
-        return query("SELECT * FROM leases WHERE consumer_id = ? ORDER BY cursor_id", LEASE_MAPPER, consumerId);
+    public List<Lease> findBySession(final String sessionId) {
+        return query("SELECT * FROM leases WHERE session_id = ? ORDER BY cursor_id", LEASE_MAPPER, sessionId);
     }
 }

--- a/boxy-core/src/test/java/boxy/core/it/CursorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/CursorIT.java
@@ -18,15 +18,15 @@ public class CursorIT extends BaseIT {
     private CursorRepository cursorRepository;
     private ConsumerRepository consumerRepository;
     private TestData data;
-    private String consumerId;
+    private String sessionId;
 
     @BeforeEach
     void setup() {
         cursorRepository = new CursorRepository(dataSource);
         consumerRepository = new ConsumerRepository(dataSource);
         data = TestData.seed(dataSource);
-        consumerId = "cursor-consumer";
-        consumerRepository.register(consumerId, TestData.SUBSCRIPTION_A, List.of(TestData.PATH_A + "/" + TestData.TOPIC_A));
+        sessionId = "cursor-consumer";
+        consumerRepository.register(sessionId, TestData.SUBSCRIPTION_A, List.of(TestData.PATH_A + "/" + TestData.TOPIC_A));
     }
 
     @Test
@@ -36,7 +36,7 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -51,9 +51,9 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 101L));
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 102L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 101L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 102L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -68,8 +68,8 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 10L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 10L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -84,8 +84,8 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()

--- a/boxy-core/src/test/java/boxy/core/it/CursorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/CursorIT.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.List;
+import java.util.Map;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,12 +16,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CursorIT extends BaseIT {
 
     private CursorRepository cursorRepository;
+    private ConsumerRepository consumerRepository;
     private TestData data;
+    private String consumerId;
 
     @BeforeEach
     void setup() {
         cursorRepository = new CursorRepository(dataSource);
+        consumerRepository = new ConsumerRepository(dataSource);
         data = TestData.seed(dataSource);
+        consumerId = "cursor-consumer";
+        consumerRepository.register(consumerId, TestData.SUBSCRIPTION_A, List.of(TestData.PATH_A + "/" + TestData.TOPIC_A));
     }
 
     @Test
@@ -28,7 +36,7 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -43,9 +51,9 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 101L);
-        cursorRepository.commit(cursor.id(), 102L);
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 101L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 102L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -60,8 +68,8 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 10L);
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 10L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -76,8 +84,8 @@ public class CursorIT extends BaseIT {
         final var partitionId = cursor.partitionId();
 
         // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 100L);
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()

--- a/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
@@ -38,9 +38,9 @@ class EventPollIT extends BaseIT {
         final long subscriptionId = subscription.id();
         final long partitionId =
                 partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
-        final String consumerId = "consumer-0";
+        final String sessionId = "consumer-0";
 
-        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+        consumerRepository.register(sessionId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
 
         eventRepository.publish(partitionId, "{}");
         eventRepository.publish(partitionId, "{}");
@@ -49,7 +49,7 @@ class EventPollIT extends BaseIT {
 
         try (var conn = dataSource.getConnection();
              var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
-            poll.setString(1, consumerId);
+            poll.setString(1, sessionId);
 
             final var start = System.currentTimeMillis();
             for (int i = 0; i < 10_000; i++) {
@@ -73,9 +73,9 @@ class EventPollIT extends BaseIT {
         final long subscriptionId = subscription.id();
         final long partitionId =
                 partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
-        final String consumerId = "consumer-1";
+        final String sessionId = "consumer-1";
 
-        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+        consumerRepository.register(sessionId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
 
         eventRepository.publish(partitionId, "{\"v\":1}");
         eventRepository.publish(partitionId, "{\"v\":2}");
@@ -84,7 +84,7 @@ class EventPollIT extends BaseIT {
         final List<Long> polled = new ArrayList<>();
         try (var conn = dataSource.getConnection();
              var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
-            poll.setString(1, consumerId);
+            poll.setString(1, sessionId);
             poll.execute();
             try (var rs = poll.getResultSet()) {
                 while (rs.next()) {
@@ -98,7 +98,7 @@ class EventPollIT extends BaseIT {
 
         try (var conn = dataSource.getConnection();
              var ps = conn.prepareStatement(
-                     "SELECT l.consumer_id " +
+                     "SELECT l.session_id " +
                      "FROM leases l " +
                      "JOIN cursors c ON c.id = l.cursor_id " +
                      "WHERE c.subscription_id = ? AND c.partition_id = ?")) {
@@ -106,7 +106,7 @@ class EventPollIT extends BaseIT {
             ps.setLong(2, partitionId);
             try (var rs = ps.executeQuery()) {
                 assertThat(rs.next()).isTrue();
-                assertThat(rs.getString(1)).isEqualTo(consumerId);
+                assertThat(rs.getString(1)).isEqualTo(sessionId);
             }
         }
     }
@@ -117,9 +117,9 @@ class EventPollIT extends BaseIT {
         final long subscriptionId = subscription.id();
         final long partitionId =
                 partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
-        final String consumerId = "consumer-2";
+        final String sessionId = "consumer-2";
 
-        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+        consumerRepository.register(sessionId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
 
         eventRepository.publish(partitionId, "{}");
         eventRepository.publish(partitionId, "{}");
@@ -128,7 +128,7 @@ class EventPollIT extends BaseIT {
 
         final List<Long> polled = new ArrayList<>();
         try (var conn = dataSource.getConnection(); var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
-            poll.setString(1, consumerId);
+            poll.setString(1, sessionId);
             poll.execute();
             try (var rs = poll.getResultSet()) {
                 while (rs.next()) {
@@ -144,12 +144,12 @@ class EventPollIT extends BaseIT {
     @Test
     void poll_emptyBatchReturnsBackoffProbability() throws SQLException {
         final var subscription = data.subscriptions().getFirst();
-        final String consumerId = "consumer-backoff";
+        final String sessionId = "consumer-backoff";
 
-        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+        consumerRepository.register(sessionId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
 
         try (var conn = dataSource.getConnection(); var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
-            poll.setString(1, consumerId);
+            poll.setString(1, sessionId);
 
             poll.execute();
             try (var rs = poll.getResultSet()) {

--- a/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
@@ -10,6 +10,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalDouble;
 
 import static boxy.core.it.TestData.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,18 +48,18 @@ class EventPollIT extends BaseIT {
         awaitSequencer();
 
         try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 10);
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
 
             final var start = System.currentTimeMillis();
             for (int i = 0; i < 10_000; i++) {
-                try (var rs = poll.executeQuery()) {
+                poll.execute();
+                try (var rs = poll.getResultSet()) {
                     while (rs.next()) {
                         rs.getLong("event_id");
                     }
                 }
+                poll.getMoreResults();
             }
             final var end = System.currentTimeMillis();
             System.out.printf("polling took %s ms\n", (end - start));
@@ -82,15 +83,15 @@ class EventPollIT extends BaseIT {
 
         final List<Long> polled = new ArrayList<>();
         try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 10);
-            try (var rs = poll.executeQuery()) {
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            poll.execute();
+            try (var rs = poll.getResultSet()) {
                 while (rs.next()) {
                     polled.add(rs.getLong("event_id"));
                 }
             }
+            poll.getMoreResults();
         }
 
         assertThat(polled).hasSize(2);
@@ -126,19 +127,44 @@ class EventPollIT extends BaseIT {
         awaitSequencer();
 
         final List<Long> polled = new ArrayList<>();
-        try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 100);
-            try (var rs = poll.executeQuery()) {
+        try (var conn = dataSource.getConnection(); var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            poll.execute();
+            try (var rs = poll.getResultSet()) {
                 while (rs.next()) {
                     polled.add(rs.getLong("event_id"));
                 }
             }
+            poll.getMoreResults();
         }
 
         assertThat(polled).hasSize(3);
+    }
+
+    @Test
+    void poll_emptyBatchReturnsBackoffProbability() throws SQLException {
+        final var subscription = data.subscriptions().getFirst();
+        final String consumerId = "consumer-backoff";
+
+        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+
+        try (var conn = dataSource.getConnection(); var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+
+            poll.execute();
+            try (var rs = poll.getResultSet()) {
+                assertThat(rs.next()).isFalse();
+            }
+
+            assertThat(poll.getMoreResults()).isTrue();
+            try (var metadata = poll.getResultSet()) {
+                final OptionalDouble probability = metadata.next()
+                        ? OptionalDouble.of(metadata.getDouble("polling_probability"))
+                        : OptionalDouble.empty();
+                assertThat(probability).isPresent();
+                assertThat(probability.getAsDouble()).isGreaterThan(0.0).isLessThan(1.0);
+            }
+        }
     }
 
     private void awaitSequencer() {

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -104,7 +104,7 @@ CREATE TABLE cursors (
     COLLATE=utf8mb4_bin
     COMMENT='Maintains the last cursor position for each subscription/partition';
 
-CREATE TABLE consumers (
+CREATE TABLE sessions (
     id                   VARCHAR(36)  PRIMARY KEY,
     subscription_id      BIGINT       NOT NULL,
     weight               DOUBLE       NOT NULL DEFAULT 1,
@@ -113,24 +113,24 @@ CREATE TABLE consumers (
     heartbeat_deadline   DATETIME(3)  NOT NULL,
     topic_ids            JSON         NOT NULL DEFAULT (JSON_ARRAY()),
     FOREIGN KEY (subscription_id) REFERENCES subscriptions(id),
-    INDEX idx_consumers__subscription (subscription_id),
-    INDEX idx_consumers__heartbeat_detected_at (heartbeat_detected_at)
+    INDEX idx_sessions__subscription (subscription_id),
+    INDEX idx_sessions__heartbeat_detected_at (heartbeat_detected_at)
 ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_bin
-    COMMENT='Registered consumers per subscription, with capacity weight and heartbeat timestamp';
+    COMMENT='Registered consumer sessions per subscription, with capacity weight and heartbeat timestamp';
 
 CREATE TABLE leases (
     cursor_id    BIGINT      PRIMARY KEY,
-    consumer_id  VARCHAR(36) NULL,
+    session_id   VARCHAR(36) NULL,
     locked_until DATETIME(3) NULL,
-    FOREIGN KEY (cursor_id)   REFERENCES cursors (id) ON DELETE CASCADE,
-    FOREIGN KEY (consumer_id) REFERENCES consumers (id) ON DELETE SET NULL,
+    FOREIGN KEY (cursor_id) REFERENCES cursors (id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES sessions (id) ON DELETE SET NULL,
     INDEX idx_leases__lock (locked_until)
 ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_bin
-    COMMENT='Tracks cursor leases held by consumers';
+    COMMENT='Tracks cursor leases held by consumer sessions';
 
 CREATE TABLE IF NOT EXISTS unprocessed_events (
     id           BIGINT PRIMARY KEY,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
@@ -1,7 +1,7 @@
-CREATE PROCEDURE sp_consumers__deregister(IN p_consumer_id VARCHAR(36))
+CREATE PROCEDURE sp_consumers__deregister(IN p_session_id VARCHAR(36))
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END;
     START TRANSACTION;
-        DELETE FROM consumers WHERE id = p_consumer_id;
+        DELETE FROM consumers WHERE id = p_session_id;
     COMMIT;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
@@ -2,6 +2,6 @@ CREATE PROCEDURE sp_consumers__deregister(IN p_session_id VARCHAR(36))
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END;
     START TRANSACTION;
-        DELETE FROM consumers WHERE id = p_session_id;
+        DELETE FROM sessions WHERE id = p_session_id;
     COMMIT;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__gc.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__gc.sql
@@ -5,7 +5,7 @@ BEGIN
     START TRANSACTION;
 
     DELETE
-      FROM consumers
+      FROM sessions
      WHERE heartbeat_deadline <= v_timestamp;
 
     COMMIT;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE sp_consumers__register(
-    IN p_consumer_id VARCHAR(36),
+    IN p_session_id VARCHAR(36),
     IN p_subscription_name VARCHAR(500),
     IN p_topics JSON)
 BEGIN
@@ -27,7 +27,7 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Subscription does not exist';
     END IF;
 
-    SELECT heartbeat_deadline INTO v_existing_deadline FROM consumers WHERE id = p_consumer_id;
+    SELECT heartbeat_deadline INTO v_existing_deadline FROM sessions WHERE id = p_session_id;
     IF v_existing_deadline IS NOT NULL AND v_existing_deadline > v_now THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'DUPLICATE_SESSION';
     END IF;
@@ -86,9 +86,9 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'INVALID_TOPIC';
     END IF;
 
-    DELETE FROM consumers WHERE id = p_consumer_id;
+    DELETE FROM sessions WHERE id = p_session_id;
 
-    INSERT INTO consumers (
+    INSERT INTO sessions (
         id,
         subscription_id,
         weight,
@@ -97,7 +97,7 @@ BEGIN
         heartbeat_deadline,
         topic_ids)
     VALUES (
-        p_consumer_id,
+        p_session_id,
         v_subscription_id,
         1.0,
         v_now,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -8,6 +8,9 @@ BEGIN
     DECLARE v_input_count INT;
     DECLARE v_invalid_paths INT;
     DECLARE v_missing_topics INT;
+    DECLARE v_unsubscribed_topics INT;
+    DECLARE v_existing_deadline DATETIME(3);
+    DECLARE v_now DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3);
     DECLARE v_delimiter VARCHAR(10);
     DECLARE v_delimiter_length INT;
 
@@ -19,6 +22,15 @@ BEGIN
     END IF;
 
     SELECT id INTO v_subscription_id FROM subscriptions WHERE name = p_subscription_name;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Subscription does not exist';
+    END IF;
+
+    SELECT heartbeat_deadline INTO v_existing_deadline FROM consumers WHERE id = p_consumer_id;
+    IF v_existing_deadline IS NOT NULL AND v_existing_deadline > v_now THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'DUPLICATE_SESSION';
+    END IF;
 
     WITH topic_input AS (
         SELECT TRIM(jt.topic_path) AS topic_path
@@ -43,14 +55,20 @@ BEGIN
             pc.is_valid,
             fn_resolve_topic_id(pc.topic_path) AS topic_id
           FROM path_checks AS pc
+    ),
+    subscription_topics AS (
+        SELECT st.topic_id
+        FROM subscription_topics st
+        WHERE st.subscription_id = v_subscription_id
     )
     SELECT
         (SELECT COUNT(*) FROM topic_input),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 0),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 1 AND topic_id IS NULL),
+        (SELECT COUNT(*) FROM resolved r WHERE r.topic_id IS NOT NULL AND r.topic_id NOT IN (SELECT topic_id FROM subscription_topics)),
         (SELECT JSON_ARRAYAGG(topic_id)
            FROM (SELECT DISTINCT topic_id FROM resolved WHERE topic_id IS NOT NULL) AS deduped)
-    INTO v_input_count, v_invalid_paths, v_missing_topics, v_topic_ids;
+    INTO v_input_count, v_invalid_paths, v_missing_topics, v_unsubscribed_topics, v_topic_ids;
 
     IF v_input_count = 0 THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'At least one topic must be provided';
@@ -61,8 +79,14 @@ BEGIN
     END IF;
 
     IF v_missing_topics > 0 THEN
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'One or more topics do not exist';
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'INVALID_TOPIC';
     END IF;
+
+    IF v_unsubscribed_topics > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'INVALID_TOPIC';
+    END IF;
+
+    DELETE FROM consumers WHERE id = p_consumer_id;
 
     INSERT INTO consumers (
         id,
@@ -76,13 +100,8 @@ BEGIN
         p_consumer_id,
         v_subscription_id,
         1.0,
-        CURRENT_TIMESTAMP(3),
+        v_now,
         30,
-        DATE_ADD(CURRENT_TIMESTAMP(3), INTERVAL 30 SECOND),
-        v_topic_ids)
-    ON DUPLICATE KEY UPDATE
-        subscription_id = VALUES(subscription_id),
-        heartbeat_detected_at = VALUES(heartbeat_detected_at),
-        heartbeat_deadline = VALUES(heartbeat_deadline),
-        topic_ids = VALUES(topic_ids);
+        DATE_ADD(v_now, INTERVAL 30 SECOND),
+        v_topic_ids);
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
@@ -14,7 +14,7 @@ BEGIN
 
     SELECT subscription_id, topic_ids
       INTO v_subscription_id, v_topic_filter
-      FROM consumers
+      FROM sessions
      WHERE id = p_session_id;
 
     IF v_subscription_id IS NULL THEN

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
@@ -1,5 +1,56 @@
-CREATE PROCEDURE sp_cursors__commit(IN p_id BIGINT, IN p_position BIGINT)
+CREATE PROCEDURE sp_cursors__commit(
+    IN p_session_id VARCHAR(36),
+    IN p_cursor_positions JSON)
 BEGIN
-    UPDATE cursors SET position = p_position WHERE id = p_id AND position < p_position;
-END;
+    DECLARE v_subscription_id BIGINT;
+    DECLARE v_topic_filter JSON;
+    DECLARE v_expected INT;
+    DECLARE v_allowed INT;
+    DECLARE v_stale INT;
 
+    IF JSON_TYPE(p_cursor_positions) <> 'OBJECT' THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'cursor_positions_json must be a JSON object';
+    END IF;
+
+    SELECT subscription_id, topic_ids
+      INTO v_subscription_id, v_topic_filter
+      FROM consumers
+     WHERE id = p_session_id;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+    END IF;
+
+    WITH cursor_input AS (
+        SELECT CAST(jk.key_name AS UNSIGNED) AS cursor_id,
+               CAST(JSON_EXTRACT(p_cursor_positions, CONCAT('$."', jk.key_name, '"')) AS UNSIGNED) AS position
+          FROM JSON_TABLE(JSON_KEYS(p_cursor_positions), '$[*]' COLUMNS(key_name VARCHAR(255) PATH '$')) jk
+    ),
+    allowed AS (
+        SELECT ci.cursor_id, ci.position, c.position AS current_position
+          FROM cursor_input ci
+          JOIN cursors c ON c.id = ci.cursor_id AND c.subscription_id = v_subscription_id
+          JOIN JSON_TABLE(v_topic_filter, '$[*]' COLUMNS(topic_id BIGINT PATH '$')) tf ON tf.topic_id = c.topic_id
+    )
+    SELECT
+        (SELECT COUNT(*) FROM cursor_input),
+        (SELECT COUNT(*) FROM allowed),
+        (SELECT COUNT(*) FROM allowed WHERE position <= current_position)
+      INTO v_expected, v_allowed, v_stale;
+
+    IF v_expected = 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'At least one cursor must be provided';
+    END IF;
+
+    IF v_allowed < v_expected THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'INVALID_CURSOR';
+    END IF;
+
+    IF v_stale > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'STALE_COMMIT';
+    END IF;
+
+    UPDATE cursors c
+    JOIN allowed a ON a.cursor_id = c.id
+       SET c.position = a.position;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -1,11 +1,13 @@
 CREATE PROCEDURE sp_events__poll(
-    IN p_subscription_id BIGINT,
-    IN p_consumer_id     VARCHAR(36),
-    IN p_batch_size      INT
+    IN p_session_id VARCHAR(36)
 )
 BEGIN
     DECLARE v_start_key INT DEFAULT fn_random_int();
     DECLARE v_now       DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3);
+    DECLARE v_subscription_id BIGINT;
+    DECLARE v_heartbeat_interval DOUBLE;
+    DECLARE v_event_count INT DEFAULT 0;
+    DECLARE v_polling_probability DOUBLE DEFAULT 0.001;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_selected_sequences;
     CREATE TEMPORARY TABLE tmp_selected_sequences (
@@ -16,9 +18,29 @@ BEGIN
         PRIMARY KEY (cursor_id, sequence)
     ) ENGINE = MEMORY;
 
+    SELECT subscription_id, heartbeat_interval
+      INTO v_subscription_id, v_heartbeat_interval
+      FROM consumers WHERE id = p_session_id;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+    END IF;
+
+    UPDATE consumers
+       SET heartbeat_detected_at = v_now,
+           heartbeat_deadline = DATE_ADD(v_now, INTERVAL v_heartbeat_interval SECOND)
+     WHERE id = p_session_id;
+
     /* 1) Capture the rows we plan to lock */
     INSERT INTO tmp_selected_sequences (cursor_id, partition_id, sequence, event_id)
-    WITH candidate AS (
+    WITH topic_filter AS (
+        SELECT jt.topic_id
+          FROM consumers c
+          JOIN JSON_TABLE(c.topic_ids, '$[*]' COLUMNS(topic_id BIGINT PATH '$')) AS jt
+            ON TRUE
+         WHERE c.id = p_session_id
+    ),
+    candidate AS (
         SELECT
             c.id AS cursor_id,
             c.partition_id,
@@ -28,6 +50,7 @@ BEGIN
                 ORDER BY (c.random_key >= v_start_key) DESC, c.random_key, c.id, s.sequence
             ) AS row_num
         FROM cursors c
+        JOIN topic_filter tf ON tf.topic_id = c.topic_id
         JOIN partitions p ON p.id = c.partition_id
         LEFT JOIN leases l ON l.cursor_id = c.id
         JOIN LATERAL (
@@ -36,19 +59,22 @@ BEGIN
             WHERE s.partition_id = c.partition_id
               AND s.sequence > c.position
             ORDER BY s.sequence
+            LIMIT 100
         ) s ON TRUE
-        WHERE c.subscription_id = p_subscription_id
+        WHERE c.subscription_id = v_subscription_id
           AND (
               l.cursor_id IS NULL OR
               l.locked_until IS NULL OR
               l.locked_until < v_now OR
-              l.consumer_id = p_consumer_id
+              l.consumer_id = p_session_id
           )
           AND p.high_watermark > c.position
     )
     SELECT cursor_id, partition_id, sequence, event_id
     FROM candidate
-    WHERE row_num <= p_batch_size;
+    WHERE row_num <= 100;
+
+    SELECT COUNT(*) INTO v_event_count FROM tmp_selected_sequences;
 
     /* 2) Lock the selected cursors */
     INSERT INTO leases (cursor_id)
@@ -60,9 +86,9 @@ BEGIN
 
     UPDATE leases l
     JOIN tmp_selected_sequences sel ON sel.cursor_id = l.cursor_id
-    SET l.consumer_id  = p_consumer_id,
+    SET l.consumer_id  = p_session_id,
         l.locked_until = DATE_ADD(v_now, INTERVAL 3 SECOND)
-    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_consumer_id;
+    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_session_id;
 
     /* 3) Return the events for rows we actually hold now */
     SELECT
@@ -75,9 +101,12 @@ BEGIN
     JOIN cursors c ON c.id = sel.cursor_id
     JOIN leases l
       ON l.cursor_id = sel.cursor_id
-     AND l.consumer_id = p_consumer_id
+     AND l.consumer_id = p_session_id
     JOIN events e
       ON e.id = sel.event_id;
+
+    SET v_polling_probability = IF(v_event_count = 0, 0.001, 1.0);
+    SELECT v_polling_probability AS polling_probability;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_selected_sequences;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -20,13 +20,13 @@ BEGIN
 
     SELECT subscription_id, heartbeat_interval
       INTO v_subscription_id, v_heartbeat_interval
-      FROM consumers WHERE id = p_session_id;
+      FROM sessions WHERE id = p_session_id;
 
     IF v_subscription_id IS NULL THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
     END IF;
 
-    UPDATE consumers
+    UPDATE sessions
        SET heartbeat_detected_at = v_now,
            heartbeat_deadline = DATE_ADD(v_now, INTERVAL v_heartbeat_interval SECOND)
      WHERE id = p_session_id;
@@ -35,9 +35,9 @@ BEGIN
     INSERT INTO tmp_selected_sequences (cursor_id, partition_id, sequence, event_id)
     WITH topic_filter AS (
         SELECT jt.topic_id
-          FROM consumers c
-          JOIN JSON_TABLE(c.topic_ids, '$[*]' COLUMNS(topic_id BIGINT PATH '$')) AS jt
-            ON TRUE
+        FROM sessions c
+        JOIN JSON_TABLE(c.topic_ids, '$[*]' COLUMNS(topic_id BIGINT PATH '$')) AS jt
+          ON TRUE
          WHERE c.id = p_session_id
     ),
     candidate AS (
@@ -66,7 +66,7 @@ BEGIN
               l.cursor_id IS NULL OR
               l.locked_until IS NULL OR
               l.locked_until < v_now OR
-              l.consumer_id = p_session_id
+              l.session_id = p_session_id
           )
           AND p.high_watermark > c.position
     )
@@ -86,9 +86,9 @@ BEGIN
 
     UPDATE leases l
     JOIN tmp_selected_sequences sel ON sel.cursor_id = l.cursor_id
-    SET l.consumer_id  = p_session_id,
+    SET l.session_id  = p_session_id,
         l.locked_until = DATE_ADD(v_now, INTERVAL 3 SECOND)
-    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_session_id;
+    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.session_id = p_session_id;
 
     /* 3) Return the events for rows we actually hold now */
     SELECT
@@ -101,7 +101,7 @@ BEGIN
     JOIN cursors c ON c.id = sel.cursor_id
     JOIN leases l
       ON l.cursor_id = sel.cursor_id
-     AND l.consumer_id = p_session_id
+     AND l.session_id = p_session_id
     JOIN events e
       ON e.id = sel.event_id;
 


### PR DESCRIPTION
## Summary
- update consumer register/poll/commit/deregister stored procedures to follow session-based protocol, enforce topic validation, and emit polling metadata
- refresh cursor repository and integration tests to use session-scoped commit JSON payloads
- add polling backoff integration test matching documented client protocol

## Testing
- mvn test *(fails in this environment: no Docker available for Testcontainers)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692374e4d230832f865d858d748df1b3)