### PR TITLE
Align consumer protocol stored procedures and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ Properties
 ## Client Consumer Protocol
 
 The Client Consumer Protocol defines how a client implementation for a given programming language must interact with Boxy. 
-All interaction occurs via stored procedures, and each client instance is identified by a `session_id` that must 
+All interaction occurs via stored procedures, and each client instance is identified by a `consumer_id` that must 
 be supplied on every call. Each stored procedure call is atomic. Database connections do not need to be reused between calls,  
 and transactions may not span multiple client consumer calls.
 
 The protocol specifies how clients register, poll for events, apply backoff when idle, and commit offsets. 
 It is designed to support large-scale fan-out with many concurrent clients while strictly limiting the total polling 
 and heartbeat queries per subscription. As an implementer, you can treat the protocol as a small, well-defined 
-state machine driven by stored procedure calls keyed by `session_id`.
+state machine driven by stored procedure calls keyed by `consumer_id`.
 
 ### Consumer Stored Procedures
 
@@ -171,7 +171,7 @@ At a minimum, a client consumer implementation must use the following stored pro
 
 #### Registration Procedure
 
-`sp_consumers__register(session_id, subscription_name, topics_json)`
+`sp_consumers__register(consumer_id, subscription_name, topics_json)`
 Registers a consumer against a subscription and declares the set of topics it intends to consume.
 A single consumer is bound to one subscription name for a given topic (or multi-topic pattern).
 A process / service can create multiple consumer instances, each with its own subscription name (even on the same topics),
@@ -179,18 +179,18 @@ and thereby “use more than one subscription name” overall.
 
 Parameters:
 
-  * `session_id` is the identifier for the consumer session and is used on every subsequent call.
+  * `consumer_id` is the identifier for the consumer and is used on every subsequent call.
        It MUST be a high-entropy identifier (UUIDv4 recommended), MUST NOT be reused across registrations,
-       and the server will reject duplicate `session_id` values that are still active. After a crash the client
-       may immediately re-register with a new `session_id` using the same `subscription_name` and `topics_json`.
+       and the server will reject duplicate `consumer_id` values that are still active. After a crash the client
+       may immediately re-register with a new `consumer_id` using the same `subscription_name` and `topics_json`.
   * `subscription_name` refers to a subscription that already links to one or more topics.
   * `topics_json` is a JSON array of fully qualified topic paths, selecting a subset of the subscription’s topics for this consumer.
        Wildcards/patterns are not supported; unknown topics are rejected with `INVALID_TOPIC`. A consumer may re-register
-       with a new `session_id` and different `topics_json` to change its coverage.
+       with a new `consumer_id` and different `topics_json` to change its coverage.
 
 #### Polling Procedure
 
-`sp_events__poll(session_id)`
+`sp_events__poll(consumer_id)`
 Polling procedure that returns the next events plus polling frequency guidance.
 When a client `poll`s after registration, it will receive events starting from the `last committed position`
 for the topics it has registered. Subsequent calls to `poll` will receive events from the `last read position` for
@@ -202,7 +202,7 @@ ignoring guidance on polling frequency; if no events are received,
 the client MUST use the returned metadata to determine the next polling time.
   
 Parameters:
-* `session_id` identify the session.
+* `consumer_id` identify the consumer.
 
 The procedure returns two result sets. The first result set will be the events, the second result set will be the metadata with the following columns:
 
@@ -213,9 +213,9 @@ The procedure returns two result sets. The first result set will be the events, 
 
 #### Commit Procedure
 
-`sp_cursors__commit(session_id, cursor_positions_json)`
+`sp_cursors__commit(consumer_id, cursor_positions_json)`
 Records the consumer’s progress for one or more topics after successful processing of events.
-Each commit advances the stored position for the corresponding cursors, so that subsequent sessions
+Each commit advances the stored position for the corresponding cursors, so that subsequent consumers
 continue reading from the `last committed position`.
 
 An implementation can decide when to call `commit`. It is not necessary to call `commit` after every
@@ -228,21 +228,21 @@ since its last commit. Batching commits (e.g., “every N events or every T ms, 
 to reduce database writes.
 
 Parameters:
-* `session_id` identify the session.
+* `consumer_id` identify the consumer.
 * `cursor_positions_json` a JSON map of one or more `cursor_id` and `position` entries,
   with the `cursor_id` as the map key, and `position` as the map value.
 
 #### Deregistration Procedure
 
-`sp_consumers__deregister(session_id)`
+`sp_consumers__deregister(consumer_id)`
 SHOULD be called when a client is shutting down.
 Before deregistering, an implementation SHOULD complete processing of inflight events and commit cursor positions.
 If an implementation becomes inactive without calling `deregister` other consumers will be blocked until deadlines pass
 (`heartbeat_deadline` ≈ 3 × expected heartbeat interval). After deregistering, an implementation MUST NOT make further
-calls with the same `session_id`.
+calls with the same `consumer_id`.
 
 Parameters:
-* `session_id` identify the session.
+* `consumer_id` identify the consumer.
 
 ### Lifecycle and state names
 
@@ -264,12 +264,12 @@ State transitions (client side)
 
 ### Error handling and observability
 
-| Procedure  | Example error codes/messages         | Recommended client action                          |
-| ---------- |--------------------------------------| -------------------------------------------------- |
-| register   | `INVALID_TOPIC`, `DUPLICATE_SESSION` | Fail fast; regenerate `session_id` and retry       |
-| poll       | `UNKNOWN_SESSION`                    | Re-register if unknown; serialize polls and retry  |
-| commit     | `UNKNOWN_SESSION`, `STALE_COMMIT`    | Re-register if unknown; drop or refresh cursors    |
-| deregister | `UNKNOWN_SESSION`                    | Ignore; session already expired                    |
+| Procedure  | Example error codes/messages          | Recommended client action                         |
+| ---------- |---------------------------------------|---------------------------------------------------|
+| register   | `INVALID_TOPIC`, `DUPLICATE_CONSUMER` | Fail fast; regenerate `consumer_id` and retry     |
+| poll       | `UNKNOWN_CONSUMER`                    | Re-register if unknown; serialize polls and retry |
+| commit     | `UNKNOWN_CONSUMER`, `STALE_COMMIT`    | Re-register if unknown; drop or refresh cursors   |
+| deregister | `UNKNOWN_CONSUMER`                    | Ignore; consumer already deregistered             |
 
   
 ## Building the Project

--- a/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
@@ -5,7 +5,9 @@ import boxy.core.domain.Cursor;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class CursorRepository extends BaseRepository {
 
@@ -15,8 +17,8 @@ public final class CursorRepository extends BaseRepository {
         super(ds);
     }
 
-    public void commit(final long id, final long position) {
-        update("{CALL sp_cursors__commit(?,?)}", id, position);
+    public void commit(final String sessionId, final Map<Long, Long> cursorPositions) {
+        update("{CALL sp_cursors__commit(?,?)}", sessionId, toJsonObject(cursorPositions));
     }
 
     public Optional<Cursor> find(final long id) {
@@ -33,4 +35,9 @@ public final class CursorRepository extends BaseRepository {
                 CURSOR_MAPPER, subscriptionId);
     }
 
+    private String toJsonObject(final Map<Long, Long> cursorPositions) {
+        return cursorPositions.entrySet().stream()
+                .map(e -> "\"" + e.getKey() + "\":" + e.getValue())
+                .collect(Collectors.joining(",", "{", "}"));
+    }
 }

--- a/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
+++ b/boxy-core/src/main/java/boxy/core/repository/CursorRepository.java
@@ -17,8 +17,8 @@ public final class CursorRepository extends BaseRepository {
         super(ds);
     }
 
-    public void commit(final String sessionId, final Map<Long, Long> cursorPositions) {
-        update("{CALL sp_cursors__commit(?,?)}", sessionId, toJsonObject(cursorPositions));
+    public void commit(final String consumerId, final Map<Long, Long> cursorPositions) {
+        update("{CALL sp_cursors__commit(?,?)}", consumerId, toJsonObject(cursorPositions));
     }
 
     public Optional<Cursor> find(final long id) {

--- a/boxy-core/src/test/java/boxy/core/it/CursorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/CursorIT.java
@@ -1,24 +1,34 @@
 package boxy.core.it;
 
-import boxy.core.repository.*;
 import boxy.core.domain.Cursor;
+import boxy.core.repository.ConsumerRepository;
+import boxy.core.repository.CursorRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.List;
+import java.util.Map;
 
+import static boxy.core.it.TestData.PATH_A;
+import static boxy.core.it.TestData.TOPIC_A;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 public class CursorIT extends BaseIT {
 
     private CursorRepository cursorRepository;
+    private ConsumerRepository consumerRepository;
     private TestData data;
+    private String sessionId;
 
     @BeforeEach
     void setup() {
         cursorRepository = new CursorRepository(dataSource);
+        consumerRepository = new ConsumerRepository(dataSource);
         data = TestData.seed(dataSource);
+        sessionId = "cursor-test-session";
+        consumerRepository.register(sessionId, data.subscriptions().getFirst().name(), List.of(PATH_A + "/" + TOPIC_A));
     }
 
     @Test
@@ -27,8 +37,7 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -42,10 +51,9 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 101L);
-        cursorRepository.commit(cursor.id(), 102L);
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 101L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 102L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -59,9 +67,8 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 10L);
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 10L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -75,9 +82,8 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        // COMMIT HWM
-        cursorRepository.commit(cursor.id(), 100L);
-        cursorRepository.commit(cursor.id(), 100L);
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()

--- a/boxy-core/src/test/java/boxy/core/it/CursorIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/CursorIT.java
@@ -20,15 +20,15 @@ public class CursorIT extends BaseIT {
     private CursorRepository cursorRepository;
     private ConsumerRepository consumerRepository;
     private TestData data;
-    private String sessionId;
+    private String consumerId;
 
     @BeforeEach
     void setup() {
         cursorRepository = new CursorRepository(dataSource);
         consumerRepository = new ConsumerRepository(dataSource);
         data = TestData.seed(dataSource);
-        sessionId = "cursor-test-session";
-        consumerRepository.register(sessionId, data.subscriptions().getFirst().name(), List.of(PATH_A + "/" + TOPIC_A));
+        consumerId = "cursor-test-consumer";
+        consumerRepository.register(consumerId, data.subscriptions().getFirst().name(), List.of(PATH_A + "/" + TOPIC_A));
     }
 
     @Test
@@ -37,7 +37,7 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -51,9 +51,9 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 101L));
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 102L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 101L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 102L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -67,8 +67,8 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 10L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 10L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()
@@ -82,8 +82,8 @@ public class CursorIT extends BaseIT {
         final var subscriptionId = data.subscriptions().getFirst().id();
         final var partitionId = cursor.partitionId();
 
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
-        cursorRepository.commit(sessionId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
+        cursorRepository.commit(consumerId, Map.of(cursor.id(), 100L));
         assertThat(cursorRepository.find(subscriptionId, partitionId))
                 .isPresent()
                 .get()

--- a/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
+++ b/boxy-core/src/test/java/boxy/core/it/EventPollIT.java
@@ -1,6 +1,7 @@
 package boxy.core.it;
 
 import boxy.core.repository.ConsumerRepository;
+import boxy.core.repository.CursorRepository;
 import boxy.core.repository.EventRepository;
 import boxy.core.repository.PartitionRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static boxy.core.it.TestData.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +22,7 @@ class EventPollIT extends BaseIT {
     private EventRepository eventRepository;
     private PartitionRepository partitionRepository;
     private ConsumerRepository consumerRepository;
+    private CursorRepository cursorRepository;
     private TestData data;
 
     @BeforeEach
@@ -27,6 +30,7 @@ class EventPollIT extends BaseIT {
         eventRepository = new EventRepository(dataSource);
         partitionRepository = new PartitionRepository(dataSource);
         consumerRepository = new ConsumerRepository(dataSource);
+        cursorRepository = new CursorRepository(dataSource);
         data = TestData.seed(dataSource);
     }
 
@@ -34,7 +38,6 @@ class EventPollIT extends BaseIT {
     @Test
     void poll_benchmarkOverhead() throws SQLException {
         final var subscription = data.subscriptions().getFirst();
-        final long subscriptionId = subscription.id();
         final long partitionId =
                 partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
         final String consumerId = "consumer-0";
@@ -47,16 +50,22 @@ class EventPollIT extends BaseIT {
         awaitSequencer();
 
         try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 10);
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
 
             final var start = System.currentTimeMillis();
             for (int i = 0; i < 10_000; i++) {
-                try (var rs = poll.executeQuery()) {
-                    while (rs.next()) {
-                        rs.getLong("event_id");
+                boolean hasResults = poll.execute();
+                if (hasResults) {
+                    try (var rs = poll.getResultSet()) {
+                        while (rs.next()) {
+                            rs.getLong("event_id");
+                        }
+                    }
+                }
+                while (poll.getMoreResults()) {
+                    try (var ignored = poll.getResultSet()) {
+                        // consume metadata
                     }
                 }
             }
@@ -82,13 +91,19 @@ class EventPollIT extends BaseIT {
 
         final List<Long> polled = new ArrayList<>();
         try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 10);
-            try (var rs = poll.executeQuery()) {
-                while (rs.next()) {
-                    polled.add(rs.getLong("event_id"));
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            boolean hasResults = poll.execute();
+            if (hasResults) {
+                try (var rs = poll.getResultSet()) {
+                    while (rs.next()) {
+                        polled.add(rs.getLong("event_id"));
+                    }
+                }
+            }
+            while (poll.getMoreResults()) {
+                try (var ignored = poll.getResultSet()) {
+                    // consume metadata
                 }
             }
         }
@@ -98,9 +113,9 @@ class EventPollIT extends BaseIT {
         try (var conn = dataSource.getConnection();
              var ps = conn.prepareStatement(
                      "SELECT l.consumer_id " +
-                     "FROM leases l " +
-                     "JOIN cursors c ON c.id = l.cursor_id " +
-                     "WHERE c.subscription_id = ? AND c.partition_id = ?")) {
+                             "FROM leases l " +
+                             "JOIN cursors c ON c.id = l.cursor_id " +
+                             "WHERE c.subscription_id = ? AND c.partition_id = ?")) {
             ps.setLong(1, subscriptionId);
             ps.setLong(2, partitionId);
             try (var rs = ps.executeQuery()) {
@@ -113,7 +128,6 @@ class EventPollIT extends BaseIT {
     @Test
     void poll_respectsBatchSize() throws SQLException {
         final var subscription = data.subscriptions().getFirst();
-        final long subscriptionId = subscription.id();
         final long partitionId =
                 partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
         final String consumerId = "consumer-2";
@@ -127,18 +141,79 @@ class EventPollIT extends BaseIT {
 
         final List<Long> polled = new ArrayList<>();
         try (var conn = dataSource.getConnection();
-             var poll = conn.prepareCall("{CALL sp_events__poll(?,?,?)}")) {
-            poll.setLong(1, subscriptionId);
-            poll.setString(2, consumerId);
-            poll.setInt(3, 100);
-            try (var rs = poll.executeQuery()) {
-                while (rs.next()) {
-                    polled.add(rs.getLong("event_id"));
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            boolean hasResults = poll.execute();
+            if (hasResults) {
+                try (var rs = poll.getResultSet()) {
+                    while (rs.next()) {
+                        polled.add(rs.getLong("event_id"));
+                    }
+                }
+            }
+            while (poll.getMoreResults()) {
+                try (var ignored = poll.getResultSet()) {
+                    // consume metadata
                 }
             }
         }
 
         assertThat(polled).hasSize(3);
+    }
+
+    @Test
+    void poll_returnsMetadataAfterCommitAndBackoff() throws SQLException {
+        final var subscription = data.subscriptions().getFirst();
+        final long partitionId =
+                partitionRepository.find(TestData.PATH_A, TOPIC_A, 0).orElseThrow().id();
+        final String consumerId = "consumer-3";
+
+        consumerRepository.register(consumerId, subscription.name(), List.of(PATH_A + "/" + TOPIC_A));
+
+        eventRepository.publish(partitionId, "{\"v\":3}");
+        awaitSequencer();
+
+        long cursorId = -1L;
+        long sequence = -1L;
+        try (var conn = dataSource.getConnection();
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            boolean hasResults = poll.execute();
+            if (hasResults) {
+                try (var rs = poll.getResultSet()) {
+                    assertThat(rs.next()).isTrue();
+                    cursorId = rs.getLong("cursor_id");
+                    sequence = rs.getLong("sequence");
+                }
+            }
+            while (poll.getMoreResults()) {
+                try (var ignored = poll.getResultSet()) {
+                    // consume metadata from first poll
+                }
+            }
+        }
+
+        cursorRepository.commit(consumerId, Map.of(cursorId, sequence));
+
+        double pollingProbability = -1;
+        try (var conn = dataSource.getConnection();
+             var poll = conn.prepareCall("{CALL sp_events__poll(?)}")) {
+            poll.setString(1, consumerId);
+            boolean hasResults = poll.execute();
+            if (hasResults) {
+                try (var rs = poll.getResultSet()) {
+                    assertThat(rs.next()).isFalse();
+                }
+            }
+            if (poll.getMoreResults()) {
+                try (var rs = poll.getResultSet()) {
+                    assertThat(rs.next()).isTrue();
+                    pollingProbability = rs.getDouble("polling_probability");
+                }
+            }
+        }
+
+        assertThat(pollingProbability).isGreaterThan(0);
     }
 
     private void awaitSequencer() {

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
@@ -1,8 +1,8 @@
-CREATE PROCEDURE sp_consumers__deregister(IN p_session_id VARCHAR(36))
+CREATE PROCEDURE sp_consumers__deregister(IN p_consumer_id VARCHAR(36))
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END;
     START TRANSACTION;
-        UPDATE leases SET consumer_id = NULL, locked_until = NULL WHERE consumer_id = p_session_id;
-        DELETE FROM consumers WHERE id = p_session_id;
+        UPDATE leases SET consumer_id = NULL, locked_until = NULL WHERE consumer_id = p_consumer_id;
+        DELETE FROM consumers WHERE id = p_consumer_id;
     COMMIT;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__deregister.sql
@@ -1,7 +1,8 @@
-CREATE PROCEDURE sp_consumers__deregister(IN p_consumer_id VARCHAR(36))
+CREATE PROCEDURE sp_consumers__deregister(IN p_session_id VARCHAR(36))
 BEGIN
     DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN ROLLBACK; END;
     START TRANSACTION;
-        DELETE FROM consumers WHERE id = p_consumer_id;
+        UPDATE leases SET consumer_id = NULL, locked_until = NULL WHERE consumer_id = p_session_id;
+        DELETE FROM consumers WHERE id = p_session_id;
     COMMIT;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE sp_consumers__register(
-    IN p_consumer_id VARCHAR(36),
+    IN p_session_id VARCHAR(36),
     IN p_subscription_name VARCHAR(500),
     IN p_topics JSON)
 BEGIN
@@ -8,8 +8,11 @@ BEGIN
     DECLARE v_input_count INT;
     DECLARE v_invalid_paths INT;
     DECLARE v_missing_topics INT;
+    DECLARE v_missing_subscriptions INT;
     DECLARE v_delimiter VARCHAR(10);
     DECLARE v_delimiter_length INT;
+    DECLARE v_now DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3);
+    DECLARE v_existing_deadline DATETIME(3);
 
     SET v_delimiter = fn_resolve_namespace_delimiter();
     SET v_delimiter_length = CHAR_LENGTH(v_delimiter);
@@ -19,6 +22,15 @@ BEGIN
     END IF;
 
     SELECT id INTO v_subscription_id FROM subscriptions WHERE name = p_subscription_name;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Subscription does not exist';
+    END IF;
+
+    SELECT heartbeat_deadline INTO v_existing_deadline FROM consumers WHERE id = p_session_id;
+    IF v_existing_deadline IS NOT NULL AND v_existing_deadline > v_now THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'DUPLICATE_SESSION';
+    END IF;
 
     WITH topic_input AS (
         SELECT TRIM(jt.topic_path) AS topic_path
@@ -48,9 +60,12 @@ BEGIN
         (SELECT COUNT(*) FROM topic_input),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 0),
         (SELECT COUNT(*) FROM resolved WHERE is_valid = 1 AND topic_id IS NULL),
+        (SELECT COUNT(*) FROM resolved WHERE topic_id IS NOT NULL AND topic_id NOT IN (
+            SELECT topic_id FROM subscription_topics WHERE subscription_id = v_subscription_id
+        )),
         (SELECT JSON_ARRAYAGG(topic_id)
            FROM (SELECT DISTINCT topic_id FROM resolved WHERE topic_id IS NOT NULL) AS deduped)
-    INTO v_input_count, v_invalid_paths, v_missing_topics, v_topic_ids;
+    INTO v_input_count, v_invalid_paths, v_missing_topics, v_missing_subscriptions, v_topic_ids;
 
     IF v_input_count = 0 THEN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'At least one topic must be provided';
@@ -64,6 +79,12 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'One or more topics do not exist';
     END IF;
 
+    IF v_missing_subscriptions > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'One or more topics are not part of the subscription';
+    END IF;
+
+    DELETE FROM consumers WHERE id = p_session_id;
+
     INSERT INTO consumers (
         id,
         subscription_id,
@@ -73,16 +94,11 @@ BEGIN
         heartbeat_deadline,
         topic_ids)
     VALUES (
-        p_consumer_id,
+        p_session_id,
         v_subscription_id,
         1.0,
-        CURRENT_TIMESTAMP(3),
+        v_now,
         30,
-        DATE_ADD(CURRENT_TIMESTAMP(3), INTERVAL 30 SECOND),
-        v_topic_ids)
-    ON DUPLICATE KEY UPDATE
-        subscription_id = VALUES(subscription_id),
-        heartbeat_detected_at = VALUES(heartbeat_detected_at),
-        heartbeat_deadline = VALUES(heartbeat_deadline),
-        topic_ids = VALUES(topic_ids);
+        DATE_ADD(v_now, INTERVAL 30 SECOND),
+        v_topic_ids);
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE sp_consumers__register(
-    IN p_session_id VARCHAR(36),
+    IN p_consumer_id VARCHAR(36),
     IN p_subscription_name VARCHAR(500),
     IN p_topics JSON)
 BEGIN
@@ -27,9 +27,9 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Subscription does not exist';
     END IF;
 
-    SELECT heartbeat_deadline INTO v_existing_deadline FROM consumers WHERE id = p_session_id;
+    SELECT heartbeat_deadline INTO v_existing_deadline FROM consumers WHERE id = p_consumer_id;
     IF v_existing_deadline IS NOT NULL AND v_existing_deadline > v_now THEN
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'DUPLICATE_SESSION';
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'DUPLICATE_CONSUMER';
     END IF;
 
     WITH topic_input AS (
@@ -83,7 +83,7 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'One or more topics are not part of the subscription';
     END IF;
 
-    DELETE FROM consumers WHERE id = p_session_id;
+    DELETE FROM consumers WHERE id = p_consumer_id;
 
     INSERT INTO consumers (
         id,
@@ -94,7 +94,7 @@ BEGIN
         heartbeat_deadline,
         topic_ids)
     VALUES (
-        p_session_id,
+        p_consumer_id,
         v_subscription_id,
         1.0,
         v_now,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE sp_cursors__commit(
-    IN p_session_id VARCHAR(36),
+    IN p_consumer_id VARCHAR(36),
     IN p_cursor_positions JSON)
 BEGIN
     DECLARE v_subscription_id BIGINT;
@@ -10,10 +10,10 @@ BEGIN
         SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'cursor_positions_json must be a JSON object map';
     END IF;
 
-    SELECT subscription_id INTO v_subscription_id FROM consumers WHERE id = p_session_id;
+    SELECT subscription_id INTO v_subscription_id FROM consumers WHERE id = p_consumer_id;
 
     IF v_subscription_id IS NULL THEN
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_CONSUMER';
     END IF;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_cursor_updates;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
@@ -1,5 +1,52 @@
-CREATE PROCEDURE sp_cursors__commit(IN p_id BIGINT, IN p_position BIGINT)
+CREATE PROCEDURE sp_cursors__commit(
+    IN p_session_id VARCHAR(36),
+    IN p_cursor_positions JSON)
 BEGIN
-    UPDATE cursors SET position = p_position WHERE id = p_id AND position < p_position;
-END;
+    DECLARE v_subscription_id BIGINT;
+    DECLARE v_input_count INT DEFAULT 0;
+    DECLARE v_updated_count INT DEFAULT 0;
 
+    IF JSON_TYPE(p_cursor_positions) <> 'OBJECT' THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'cursor_positions_json must be a JSON object map';
+    END IF;
+
+    SELECT subscription_id INTO v_subscription_id FROM consumers WHERE id = p_session_id;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+    END IF;
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_cursor_updates;
+    CREATE TEMPORARY TABLE tmp_cursor_updates (
+        cursor_id BIGINT PRIMARY KEY,
+        position  BIGINT NOT NULL
+    ) ENGINE = MEMORY;
+
+    INSERT INTO tmp_cursor_updates (cursor_id, position)
+    SELECT CAST(jt.cursor_key AS UNSIGNED),
+           CAST(JSON_UNQUOTE(JSON_EXTRACT(p_cursor_positions, CONCAT('$.', jt.cursor_key))) AS UNSIGNED)
+      FROM JSON_TABLE(JSON_KEYS(p_cursor_positions), '$[*]' COLUMNS(cursor_key VARCHAR(64) PATH '$')) AS jt;
+
+    SELECT COUNT(*) INTO v_input_count FROM tmp_cursor_updates;
+
+    IF v_input_count = 0 THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'At least one cursor position must be provided';
+    END IF;
+
+    SELECT COUNT(*) INTO v_updated_count
+      FROM tmp_cursor_updates u
+      JOIN cursors c ON c.id = u.cursor_id AND c.subscription_id = v_subscription_id
+     WHERE u.position > c.position;
+
+    IF v_updated_count < v_input_count THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'STALE_COMMIT';
+    END IF;
+
+    UPDATE cursors c
+      JOIN tmp_cursor_updates u ON u.cursor_id = c.id
+       SET c.position = u.position
+     WHERE c.subscription_id = v_subscription_id
+       AND u.position > c.position;
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_cursor_updates;
+END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -1,11 +1,25 @@
 CREATE PROCEDURE sp_events__poll(
-    IN p_subscription_id BIGINT,
-    IN p_consumer_id     VARCHAR(36),
-    IN p_batch_size      INT
+    IN p_session_id VARCHAR(36)
 )
 BEGIN
     DECLARE v_start_key INT DEFAULT fn_random_int();
     DECLARE v_now       DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3);
+    DECLARE v_subscription_id BIGINT;
+    DECLARE v_topic_ids JSON;
+    DECLARE v_batch_size INT DEFAULT 100;
+
+    SELECT subscription_id, topic_ids INTO v_subscription_id, v_topic_ids
+      FROM consumers
+     WHERE id = p_session_id;
+
+    IF v_subscription_id IS NULL THEN
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+    END IF;
+
+    UPDATE consumers
+       SET heartbeat_detected_at = v_now,
+           heartbeat_deadline = DATE_ADD(v_now, INTERVAL heartbeat_interval SECOND)
+     WHERE id = p_session_id;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_selected_sequences;
     CREATE TEMPORARY TABLE tmp_selected_sequences (
@@ -37,18 +51,19 @@ BEGIN
               AND s.sequence > c.position
             ORDER BY s.sequence
         ) s ON TRUE
-        WHERE c.subscription_id = p_subscription_id
+        WHERE c.subscription_id = v_subscription_id
+          AND JSON_CONTAINS(v_topic_ids, CAST(c.topic_id AS JSON), '$')
           AND (
               l.cursor_id IS NULL OR
               l.locked_until IS NULL OR
               l.locked_until < v_now OR
-              l.consumer_id = p_consumer_id
+              l.consumer_id = p_session_id
           )
           AND p.high_watermark > c.position
     )
     SELECT cursor_id, partition_id, sequence, event_id
     FROM candidate
-    WHERE row_num <= p_batch_size;
+    WHERE row_num <= v_batch_size;
 
     /* 2) Lock the selected cursors */
     INSERT INTO leases (cursor_id)
@@ -60,9 +75,9 @@ BEGIN
 
     UPDATE leases l
     JOIN tmp_selected_sequences sel ON sel.cursor_id = l.cursor_id
-    SET l.consumer_id  = p_consumer_id,
+    SET l.consumer_id  = p_session_id,
         l.locked_until = DATE_ADD(v_now, INTERVAL 3 SECOND)
-    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_consumer_id;
+    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_session_id;
 
     /* 3) Return the events for rows we actually hold now */
     SELECT
@@ -75,9 +90,12 @@ BEGIN
     JOIN cursors c ON c.id = sel.cursor_id
     JOIN leases l
       ON l.cursor_id = sel.cursor_id
-     AND l.consumer_id = p_consumer_id
+     AND l.consumer_id = p_session_id
     JOIN events e
       ON e.id = sel.event_id;
+
+    /* 4) Return polling metadata */
+    SELECT 0.001 AS polling_probability;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_selected_sequences;
 END;

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_events__poll.sql
@@ -1,5 +1,5 @@
 CREATE PROCEDURE sp_events__poll(
-    IN p_session_id VARCHAR(36)
+    IN p_consumer_id VARCHAR(36)
 )
 BEGIN
     DECLARE v_start_key INT DEFAULT fn_random_int();
@@ -10,16 +10,16 @@ BEGIN
 
     SELECT subscription_id, topic_ids INTO v_subscription_id, v_topic_ids
       FROM consumers
-     WHERE id = p_session_id;
+     WHERE id = p_consumer_id;
 
     IF v_subscription_id IS NULL THEN
-        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_SESSION';
+        SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'UNKNOWN_CONSUMER';
     END IF;
 
     UPDATE consumers
        SET heartbeat_detected_at = v_now,
            heartbeat_deadline = DATE_ADD(v_now, INTERVAL heartbeat_interval SECOND)
-     WHERE id = p_session_id;
+     WHERE id = p_consumer_id;
 
     DROP TEMPORARY TABLE IF EXISTS tmp_selected_sequences;
     CREATE TEMPORARY TABLE tmp_selected_sequences (
@@ -57,7 +57,7 @@ BEGIN
               l.cursor_id IS NULL OR
               l.locked_until IS NULL OR
               l.locked_until < v_now OR
-              l.consumer_id = p_session_id
+              l.consumer_id = p_consumer_id
           )
           AND p.high_watermark > c.position
     )
@@ -75,9 +75,9 @@ BEGIN
 
     UPDATE leases l
     JOIN tmp_selected_sequences sel ON sel.cursor_id = l.cursor_id
-    SET l.consumer_id  = p_session_id,
+    SET l.consumer_id  = p_consumer_id,
         l.locked_until = DATE_ADD(v_now, INTERVAL 3 SECOND)
-    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_session_id;
+    WHERE l.locked_until IS NULL OR l.locked_until < v_now OR l.consumer_id = p_consumer_id;
 
     /* 3) Return the events for rows we actually hold now */
     SELECT
@@ -90,7 +90,7 @@ BEGIN
     JOIN cursors c ON c.id = sel.cursor_id
     JOIN leases l
       ON l.cursor_id = sel.cursor_id
-     AND l.consumer_id = p_session_id
+     AND l.consumer_id = p_consumer_id
     JOIN events e
       ON e.id = sel.event_id;
 


### PR DESCRIPTION
## Summary
- update consumer stored procedures to enforce session-based protocol and return polling metadata
- adjust Java repositories and integration tests to use session-oriented polling and commits
- add protocol-focused backoff test case and lease cleanup on deregistration

## Testing
- mvn -pl boxy-core -am test *(fails: Testcontainers could not find a Docker environment in this runner)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692374e4d230832f865d858d748df1b3)