### PR TITLE
Remove consumer weight and related metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tenant isolation is provided through a hierarchical namespace system.
 
 ## Design Highlights
 
-- **Fair-share Load Balancing** across consumers, proportional to capacity weights
+- **Fair-share Load Balancing** across consumers
 - **Low Consumer Lag**: p99 ~5ms for active partitions, and ~100ms for cold partitions
 - **Scalable Polling**: consumers stagger check-ins to minimize database queries (e.g. ≈10 checks/s instead of hundreds)
 
@@ -88,7 +88,7 @@ Liquibase migrations for the schema are under `boxy-db/src/main/resources/db/cha
 - **cursors**: tracks the position per subscription and partition and stores the `subscription_id`,
   `subscription_topic_id`, and `topic_id` for join-free lookups. Each row is assigned a persistent
   `random_key` used for evenly distributing start positions among consumers.
-- **consumers**: registers each consumer’s `subscription_id`, `weight`, `heartbeat_detected_at`, and `topic_ids` JSON array of topic identifiers.
+- **consumers**: registers each consumer’s `subscription_id`, `heartbeat_detected_at`, and `topic_ids` JSON array of topic identifiers.
 - **subscriptions**: defines logical groups of consumers.
 - **topics_cache**: in-memory table for quick topic lookups.
 
@@ -99,7 +99,6 @@ The `subscription_topics` table stores precomputed statistics that are updated w
 - **heartbeat_interval**: Adaptive interval used for consumer heartbeats.
 - **active_partitions**: Count of partitions with new events (high_watermark > position).
 - **active_consumers**: Count of consumers with valid heartbeats.
-- **active_consumers_weight**: Sum of weights of all active consumers in the subscription.
 - **last_modified_at**: Timestamp of the last statistics update.
 
 These statistics are used for:
@@ -117,7 +116,6 @@ classDiagram
     class Consumer {
         +String id
         +long subscriptionId
-        +double weight
         +Instant heartbeatDetectedAt
         +double heartbeatInterval
         +Instant heartbeatDeadline

--- a/boxy-core/src/main/java/boxy/core/domain/Consumer.java
+++ b/boxy-core/src/main/java/boxy/core/domain/Consumer.java
@@ -6,7 +6,6 @@ import java.util.List;
 public record Consumer(
         String id,
         long subscriptionId,
-        double weight,
         Instant heartbeatDetectedAt,
         double heartbeatInterval,
         Instant heartbeatDeadline,

--- a/boxy-core/src/main/java/boxy/core/domain/SubscriptionTopic.java
+++ b/boxy-core/src/main/java/boxy/core/domain/SubscriptionTopic.java
@@ -9,7 +9,6 @@ public record SubscriptionTopic(
         double heartbeatInterval,
         int activePartitions,
         int activeConsumers,
-        double activeConsumersWeight,
         Instant createdAt,
         Instant lastModifiedAt) {
 }

--- a/boxy-core/src/main/java/boxy/core/mapper/ConsumerMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/ConsumerMapper.java
@@ -13,7 +13,6 @@ public class ConsumerMapper implements RowMapper<Consumer> {
         return new Consumer(
                 rs.getString("id"),
                 rs.getLong("subscription_id"),
-                rs.getDouble("weight"),
                 rs.getTimestamp("heartbeat_detected_at").toInstant(),
                 rs.getDouble("heartbeat_interval"),
                 rs.getTimestamp("heartbeat_deadline").toInstant(),

--- a/boxy-core/src/main/java/boxy/core/mapper/SubscriptionTopicMapper.java
+++ b/boxy-core/src/main/java/boxy/core/mapper/SubscriptionTopicMapper.java
@@ -15,7 +15,6 @@ public class SubscriptionTopicMapper implements RowMapper<SubscriptionTopic> {
                 rs.getDouble("heartbeat_interval"),
                 rs.getInt("active_partitions"),
                 rs.getInt("active_consumers"),
-                rs.getDouble("active_consumers_weight"),
                 rs.getTimestamp("created_at").toInstant(),
                 rs.getTimestamp("last_modified_at").toInstant());
     }

--- a/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/mysql.schema.sql
@@ -72,7 +72,6 @@ CREATE TABLE subscription_topics (
     heartbeat_interval          DOUBLE NOT NULL DEFAULT 15.0,
     active_partitions           INT NOT NULL DEFAULT 0,
     active_consumers            INT NOT NULL DEFAULT 0,
-    active_consumers_weight     DOUBLE NOT NULL DEFAULT 0,
     created_at          DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     last_modified_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     CONSTRAINT u_subscription_topics UNIQUE (subscription_id, topic_id),
@@ -107,7 +106,6 @@ CREATE TABLE cursors (
 CREATE TABLE consumers (
     id                   VARCHAR(36)  PRIMARY KEY,
     subscription_id      BIGINT       NOT NULL,
-    weight               DOUBLE       NOT NULL DEFAULT 1,
     heartbeat_detected_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     heartbeat_interval   DOUBLE       NOT NULL,
     heartbeat_deadline   DATETIME(3)  NOT NULL,
@@ -118,7 +116,7 @@ CREATE TABLE consumers (
 ) ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4
     COLLATE=utf8mb4_bin
-    COMMENT='Registered consumers per subscription, with capacity weight and heartbeat timestamp';
+    COMMENT='Registered consumers per subscription with heartbeat timestamp';
 
 CREATE TABLE leases (
     cursor_id    BIGINT      PRIMARY KEY,

--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_consumers__register.sql
@@ -88,7 +88,6 @@ BEGIN
     INSERT INTO consumers (
         id,
         subscription_id,
-        weight,
         heartbeat_detected_at,
         heartbeat_interval,
         heartbeat_deadline,
@@ -96,7 +95,6 @@ BEGIN
     VALUES (
         p_consumer_id,
         v_subscription_id,
-        1.0,
         v_now,
         30,
         DATE_ADD(v_now, INTERVAL 30 SECOND),


### PR DESCRIPTION
## Summary
- drop consumer weight and subscription active consumer weight fields from schema, mappers, and records
- simplify consumer registration procedure to omit weight handling
- update documentation to match the streamlined consumer and subscription statistics

## Testing
- mvn -pl boxy-core -am -DskipTests compile


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238a1108a8832fadb8031de7d09ec9)