### PR TITLE
Quote cursor keys in MySQL cursor commit procedure

### DIFF
--- a/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
+++ b/boxy-db/src/main/resources/db/changelog/mysql/sp/sp_cursors__commit.sql
@@ -24,7 +24,7 @@ BEGIN
 
     INSERT INTO tmp_cursor_updates (cursor_id, position)
     SELECT CAST(jt.cursor_key AS UNSIGNED),
-           CAST(JSON_UNQUOTE(JSON_EXTRACT(p_cursor_positions, CONCAT('$.', jt.cursor_key))) AS UNSIGNED)
+           CAST(JSON_UNQUOTE(JSON_EXTRACT(p_cursor_positions, CONCAT('$."', jt.cursor_key, '"'))) AS UNSIGNED)
       FROM JSON_TABLE(JSON_KEYS(p_cursor_positions), '$[*]' COLUMNS(cursor_key VARCHAR(64) PATH '$')) AS jt;
 
     SELECT COUNT(*) INTO v_input_count FROM tmp_cursor_updates;


### PR DESCRIPTION
## Summary
- quote cursor IDs in the MySQL `sp_cursors__commit` stored procedure when extracting positions
- ensure numeric cursor keys generate valid JSON path expressions

## Testing
- mvn test *(fails: Docker environment unavailable for Testcontainers integration tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239c414060832fa996771a84932c23)